### PR TITLE
RFC: Add share index prefix for k=1 replication

### DIFF
--- a/garland-v0.1.md
+++ b/garland-v0.1.md
@@ -233,7 +233,16 @@ The choice of n and k determines the tradeoff between storage overhead, fault to
 | 4 | 7 | 1.75× | 3 failures | 7 |
 | 6 | 9 | 1.50× | 3 failures | 9 |
 
-**Simple replication (k=1)**: When k=1, erasure coding degenerates to simple replication where each share is an identical copy of the full encrypted block. Any single server can provide the complete block with no decoding required. This configuration trades storage efficiency (n× overhead) for operational simplicity and maximum fault tolerance (survives n−1 failures). It suits users who prioritize simplicity over storage cost, or who have access to few servers. Note that with k=1, all servers store blobs with identical hashes, enabling potential cross-server correlation; with k>1, each share has a unique hash.
+**Simple replication (k=1)**: When k=1, erasure coding degenerates to simple replication. To ensure unique share hashes (preventing cross-server correlation), each share includes its index in the plaintext before encryption:
+
+```
+plaintext_i = [share_index: u8] || content[0:C-1]
+encrypted_block_i = encrypt(plaintext_i)
+```
+
+This reduces plaintext capacity by 1 byte for k=1 configurations (C-1 instead of C). During retrieval, the client decrypts and strips the 1-byte prefix to recover the original content.
+
+Any single server can provide the complete block with no decoding required. This configuration trades storage efficiency (n× overhead) for operational simplicity and maximum fault tolerance (survives n-1 failures). It suits users who prioritize simplicity over storage cost, or who have access to few servers.
 
 **Erasure coding (k>1)**: For personal storage, (n=3, k=2) or (n=5, k=3) provides a reasonable balance. The former tolerates one server failure with 50% overhead; the latter tolerates two failures with 67% overhead. Users with access to more servers or heightened durability requirements may choose higher parameters.
 


### PR DESCRIPTION
## Summary

When k=1 (simple replication), all n shares would contain identical encrypted blocks and thus have identical hashes. This enables cross-server correlation: an adversary controlling multiple servers can determine which shares belong to the same block.

Since Garland uses per-blob authentication keys (Section 11.2), servers see different pubkeys for each blob and cannot correlate by identity. The hash is the only correlation vector for k=1.

This PR proposes including the share index in the plaintext before encryption.

## Is this actually a problem?

The k=1 case is equivalent to storing an erasure-coded shard on multiple servers for redundancy. If a user with k>1 chose to upload the same shard to multiple servers (for extra redundancy on that shard), they would have the same "correlation" situation. This is normal redundancy behavior, not a privacy leak.

Is the added complexity worth solving what may be expected behavior rather than a problem?

## Proposed Change

```
plaintext_i = [share_index: u8] || content[0:C-1]
encrypted_block_i = encrypt(plaintext_i)
```

During retrieval, the client decrypts and strips the 1-byte prefix to recover the original content.

## Trade-off

This reduces plaintext capacity by 1 byte for k=1 configurations:
- k=1: C-1 bytes (262,099 for B=256 KiB)
- k>1: C bytes (262,100 for B=256 KiB)

This is a 0.00038% reduction. The encrypted block size remains exactly B bytes, preserving blob uniformity.

## Alternative: Do Nothing

The spec could simply document the limitation and let users decide. Users choosing k=1 are already trading privacy for simplicity.

## Finding Addressed

- 4.1 k=1 Replication Hash Correlation [LOW - Recommendation]

## Dependencies

**Base branch: `fix/structural-changes` (PR #4)**

Merge order: #1 -> #2 -> #3 -> #4 -> #5