### PR TITLE
Specify crypto transport and coding details

### DIFF
--- a/garland-v0.1.md
+++ b/garland-v0.1.md
@@ -105,28 +105,55 @@ When writing a file, the client divides data into fixed-size blocks, encrypts ea
 
 When reading a file, the client traverses from the current chain head through the directory structure to locate the target inode, fetches any k of the n shares for each block, decodes and decrypts the blocks, and reassembles the original file.
 
+### 3.1 Serialization and Wire Formats
+
+All JSON structures in this protocol (inodes, directory entries, commit content) MUST be serialized using RFC 8785 JSON Canonicalization Scheme (JCS) before hashing, signing, or encrypting them. Deterministic serialization is required for content-addressing: two implementations encoding the same logical structure must produce identical bytes.
+
+Implementations MUST NOT rely on insertion order, runtime hash map ordering, platform-specific floating point formatting, ad hoc whitespace rules, or any other non-canonical JSON behavior. Object member ordering, string escaping, Unicode handling, and number rendering MUST follow RFC 8785 exactly.
+
+**Encoding conventions:**
+- **SHA-256 hashes** (share IDs, content hashes): lowercase hex-encoded strings (64 characters)
+- **Binary data** (file_id, inode_id, nonces): standard base64 with padding (RFC 4648 Section 4)
+- **Integers in binary fields** (content_length, block_index): big-endian unsigned
+- **Integers in JSON**: decimal (standard JSON number), but values MUST remain within the I-JSON safe integer range `0 <= x <= 2^53 - 1`
+- **Strings**: UTF-8
+
+These conventions apply throughout the spec. When examples show `<content hash>` or `<share_hash>`, these are lowercase hex strings. When examples show `<base64-encoded 32-byte ...>`, these use standard base64 with `=` padding.
+
 ---
 
 ## 4. Block Layer
 
 ### 4.1 Fixed-Size Blocks
 
-All data entering the system is divided into fixed-size blocks before any cryptographic processing. The block size B is a system parameter, typically 256 KiB (262,144 bytes), though implementations may support alternative sizes for specific use cases.
+All data entering the system is divided into fixed-size blocks before any cryptographic processing. The block size B is a system parameter, fixed at 262,144 bytes (256 KiB). B refers to the total encrypted block size; the plaintext frame per block is `C = B - 44` bytes (262,100 bytes) to accommodate the 12-byte nonce and 32-byte MAC (see Section 6.2).
 
-For a file of size S bytes, the number of blocks is:
-
-```
-N_blocks = ⌈S / B⌉
-```
-
-The final block is padded to exactly B bytes using a length-prefixed padding scheme. Only the final block includes a length prefix: the first four bytes encode the actual content length as a big-endian 32-bit unsigned integer, followed by the content bytes, followed by zero bytes to fill the block:
+Every block uses a uniform length-prefixed format. The first four bytes of each plaintext frame encode the content length as a big-endian 32-bit unsigned integer, followed by the content bytes, followed by random padding to fill the frame:
 
 ```
-Non-final blocks: [content: B bytes]
-Final block:      [content_length: u32_be][content: content_length bytes][padding: zeros]
+Every block: [content_length: u32_be][content: content_length bytes][padding: random bytes to C total]
 ```
 
-This scheme enables unambiguous removal of padding during reconstruction. For the final block, content_length contains `S mod B`. A value of 0 indicates the final block is completely full, meaning the file size is an exact multiple of B. Non-final blocks contain exactly B bytes of content with no overhead.
+The effective content capacity per block is `C_eff = C - 4 = 262,096` bytes. For a file of size S bytes, the number of blocks is:
+
+```
+C = B - 44 = 262,100  (plaintext frame per block)
+C_eff = C - 4 = 262,096  (content capacity per block, after 4-byte length prefix)
+N_blocks = ⌈S / C_eff⌉   (for S > 0; N_blocks = 1 for S = 0)
+```
+
+**content_length semantics**: Each block's `content_length` field stores the number of content bytes in that block:
+
+- **Non-final blocks**: `content_length = C_eff` (the block is completely full of content after the 4-byte prefix, with zero padding bytes)
+- **Final block where `S mod C_eff > 0`**: `content_length = S mod C_eff`
+- **Final block where `S mod C_eff == 0` and `S > 0`**: `content_length = C_eff` (block is full)
+- **Empty file (S = 0)**: a single block with `content_length = 0` (4-byte prefix, then C - 4 bytes of random padding)
+
+The uniform format means every block is parsed identically: read 4-byte prefix, extract `content_length` bytes of content, discard the rest as padding. This eliminates the need to distinguish "final" from "non-final" blocks during decoding -- the only special handling is that the last block's `content_length` may be less than `C_eff`.
+
+The 4-byte-per-block overhead is negligible compared to the padding overhead already inherent in fixed-size blocks.
+
+The padding bytes MUST be randomly generated, not zeros. Random padding avoids known-plaintext at predictable locations within blocks. Since the padding is discarded during reconstruction (the decoder reads exactly `content_length` bytes after the prefix), the random bytes need not be reproducible.
 
 ### 4.2 Privacy Through Uniformity
 
@@ -309,14 +336,21 @@ Integrity is provided by the content-addressing scheme. Each share is stored and
 
 ### 6.3 Metadata Encryption
 
-File inodes and directory entries contain sensitive metadata: filenames, sizes, timestamps, and structural relationships. The client encrypts this metadata using the metadata key derived from the master key.
+File inodes and directory entries contain sensitive metadata: filenames, sizes, timestamps, and structural relationships. The client encrypts this metadata using the metadata key derived from the master key, with the same authenticated framing model used for file blocks.
 
-When storing an inode or directory, the client:
-1. Serializes the structure to JSON
-2. Pads to the fixed block size (256 KiB)
-3. Encrypts using ChaCha20 with the metadata key
-4. Erasure-codes the encrypted block into n shares
-5. Uploads shares to n servers
+When storing a single-block inode or directory, the client:
+1. Serializes the structure to RFC 8785 JCS JSON bytes
+2. Verifies that the serialized length is at most `C_eff = C - 4` bytes
+3. Frames the plaintext exactly as `[content_length: u32_be] || content || random_padding` to total `C = B - 44` bytes, using the same block format as Section 4.1
+4. Derives `enc_key = HKDF-Expand(metadata_key, "garland-v1:enc", 32)` and `mac_key = HKDF-Expand(metadata_key, "garland-v1:mac", 32)`
+5. Generates a random 12-byte nonce
+6. Encrypts using ChaCha20 with `enc_key` and nonce
+7. Computes `HMAC-SHA256(mac_key, nonce || ciphertext)`
+8. Prepends nonce and appends MAC to form a B-byte encrypted block
+9. Erasure-codes the encrypted block into n shares
+10. Uploads shares to n servers
+
+The nonce is embedded in the encrypted block, not stored separately in the parent reference. To decrypt, the client fetches the shares, reconstructs the block, extracts the nonce from the first 12 bytes, verifies the MAC, decrypts, then parses the Section 4.1 frame to recover the JSON bytes.
 
 The resulting shares are indistinguishable from file data shares. See Section 14 for detailed privacy analysis.
 
@@ -367,24 +401,24 @@ An inode contains all information necessary to reconstruct a file. After decrypt
   "size": 10485760,
   "created": 1701820800,
   "modified": 1701907200,
-  "key": "<base64-encoded encrypted file key>",
+  "file_id": "<base64-encoded 32-byte random identifier>",
   "blocks": [
     {
       "index": 0,
-      "hash": "<SHA-256 of plaintext block for integrity verification>",
+      "hash": "<SHA-256 of canonical block payload for integrity verification>",
       "shares": [
-        {"id": "<share0_sha256>", "server": "https://blossom1.example.com"},
-        {"id": "<share1_sha256>", "server": "https://blossom2.example.com"},
-        {"id": "<share2_sha256>", "server": "https://blossom3.example.com"}
+        {"id": "<share0_sha256>", "server": "https://blossom1.example.com", "auth": "blob"},
+        {"id": "<share1_sha256>", "server": "https://blossom2.example.com", "auth": "blob"},
+        {"id": "<share2_sha256>", "server": "https://blossom3.example.com", "auth": "blob"}
       ]
     },
     {
       "index": 1,
-      "hash": "<SHA-256 of plaintext block>",
+      "hash": "<SHA-256 of canonical block payload>",
       "shares": [
-        {"id": "<share0_sha256>", "server": "https://blossom1.example.com"},
-        {"id": "<share1_sha256>", "server": "https://blossom2.example.com"},
-        {"id": "<share2_sha256>", "server": "https://blossom3.example.com"}
+        {"id": "<share0_sha256>", "server": "https://blossom1.example.com", "auth": "blob"},
+        {"id": "<share1_sha256>", "server": "https://blossom2.example.com", "auth": "blob"},
+        {"id": "<share2_sha256>", "server": "https://blossom3.example.com", "auth": "blob"}
       ]
     }
   ],
@@ -397,41 +431,174 @@ An inode contains all information necessary to reconstruct a file. After decrypt
 }
 ```
 
-The `key` field contains the per-file encryption key, encrypted with the metadata key. File content is encrypted to the file key, and the file key is encrypted to the metadata key. This hierarchy enables recovery from nsec + passphrase while keeping file keys isolated.
+The `file_id` field contains a randomly generated 32-byte identifier used to derive the file's encryption key (see Section 6.1). The file key is derived as `HKDF-Expand(master_key, "garland-v1:file:" || file_id, 32)`. This identifier is stored in plaintext within the encrypted inode; an attacker who compromises only `metadata_key` can read the `file_id` but cannot derive the file key without `master_key`.
 
-The `hash` field in each block entry contains the SHA-256 hash of the plaintext block before encryption. This enables integrity verification after decryption: if the decrypted block's hash doesn't match, either the ciphertext was corrupted, the wrong key was used, or the inode itself is corrupt.
+The `hash` field in each block entry contains the SHA-256 hash of the canonical block payload before random padding is added. For file content blocks, the payload is `payload = [content_length: u32_be] || content`, where `content` has exactly `content_length` bytes. Random padding bytes are excluded from this hash because they are discarded during decoding and need not be reproduced during repair. This enables integrity verification after decryption: if the decrypted block's canonical payload hash doesn't match, either the ciphertext was corrupted, the wrong key was used, or the inode itself is corrupt.
 
 The `shares` array is ordered by share index (0 to n-1). The array position determines the share index, which is required for erasure decoding. During reconstruction, the client fetches shares from their listed servers, tracking which indices were successfully retrieved. Once k shares are obtained, decoding can proceed. Storing share indices in the inode (rather than embedding them in share data) provides better privacy: servers cannot determine a share's position in the erasure scheme.
 
+Each share descriptor contains:
+- `id`: lowercase hex SHA-256 of the stored share bytes
+- `server`: absolute HTTPS base URL used for authenticated `PUT` and `DELETE` requests
+- `url`: optional absolute retrieval URL used for `GET` and `HEAD`; if omitted, clients derive it as `server + "/" + id`
+- `auth`: authentication mode used for writes to that server: `"blob"` (per-blob key), `"identity"` (storage identity key), or `"none"` (server accepts unauthenticated writes)
+
+The `auth` field is required for interoperable deletion and repair. The optional `url` field is required whenever the server returns a retrieval endpoint on a different origin than the write endpoint. Recovery clients MUST use `url` for reads when present, and MUST use `server` plus `auth` for uploads, repairs, and deletions.
+
 The client stores inodes as blobs using the same pipeline: serialize, pad, encrypt, erasure-code, and distribute. The resulting structure's content hash forms a node in the Merkle DAG.
 
-### 7.1 Large File Inodes
+### 7.1 Large Inodes
 
-Files with many blocks may produce inodes exceeding the standard block size. With (n=5, k=3) erasure coding, each block entry requires approximately 500 bytes for share IDs and server URLs. A file with 500,000 blocks would generate a ~250 MB inode, far exceeding the 256 KiB block limit.
+Any inode (file or directory) may exceed the plaintext capacity C when serialized. With (n=5, k=3) erasure coding, each block entry requires approximately 500 bytes for share IDs and server URLs. A file with 500,000 blocks or a directory with thousands of entries could exceed the block size limit.
 
-For files exceeding approximately 500 blocks, the inode uses an indirect block structure:
+When an inode exceeds C bytes, it is stored as multiple blocks using the same framing and hashing rules as file content:
+
+1. Serialize the inode to JSON
+2. Split the serialized bytes into payload chunks of at most `C_eff` bytes, then frame each chunk as `[content_length || content || random_padding]` per Section 4.1
+3. Encrypt each block with a key derived from a single `inode_id`
+4. Erasure-code and upload each encrypted block
+5. The parent reference includes the `inode_id` and block list
+
+A multi-block inode reference in a directory entry:
+
+```json
+{
+  "photos": {
+    "type": "directory",
+    "ref": {
+      "format": "multi",
+      "inode_id": "<base64-encoded 32-byte random identifier>",
+      "erasure": {"algorithm": "reed-solomon", "k": 2, "n": 3, "field": "gf256"},
+      "blocks": [
+        {
+          "index": 0,
+          "hash": "<SHA-256 of canonical block payload>",
+          "shares": [
+            {"id": "<share0_sha256>", "server": "https://blossom1.example.com", "auth": "blob"},
+            {"id": "<share1_sha256>", "server": "https://blossom2.example.com", "auth": "blob"},
+            {"id": "<share2_sha256>", "server": "https://blossom3.example.com", "auth": "blob"}
+          ]
+        },
+        {
+          "index": 1,
+          "hash": "<SHA-256 of canonical block payload>",
+          "shares": [...]
+        }
+      ]
+    }
+  }
+}
+```
+
+The `inode_id` inside a multi-block inode reference serves the same purpose as `file_id` for file content, enabling deterministic key derivation for multi-block data:
+
+```
+inode_key = HKDF-Expand(metadata_key, "garland-v1:inode:" || inode_id, 32)
+block_key = HKDF-Expand(inode_key, "garland-v1:block:" || block_index_as_u64_be, 32)
+```
+
+Each block is then encrypted using the standard enc/mac key split: derive `enc_key` and `mac_key` from `block_key` via HKDF-Expand (Section 6.2), then encrypt with ChaCha20 and authenticate with HMAC-SHA256 using a random nonce. The `hash` field for each large-inode block follows the same canonical-payload rule as file blocks: `SHA256([content_length: u32_be] || content)`.
+
+For single-block inodes (the common case), the inode is encrypted directly with `metadata_key` and the nonce is embedded in the encrypted block. The plaintext still uses the Section 4.1 framed block format with `C_eff` content capacity. Implementations should use this simpler approach when the serialized inode fits in one block.
+
+This unified approach means the same chunking mechanism handles large files, large directories, and any future large metadata. Implementations use one code path for all cases.
+
+### 7.2 Inline Small Files
+
+Files below a configurable size threshold (default: 4 KiB) MAY be stored inline within their inode, avoiding the overhead of a separate block pipeline. A 100-byte file stored as a full block requires B bytes of encrypted storage plus n shares of size B/k each -- hundreds of kilobytes for a few bytes of content. Inlining eliminates this waste.
+
+An inline inode stores the encrypted file content directly:
 
 ```json
 {
   "version": 1,
   "type": "file",
-  "size": 137438953472,
-  "indirect": true,
-  "block_index": [
-    {"hash": "<content hash of block index chunk 0>", "shares": [...]},
-    {"hash": "<content hash of block index chunk 1>", "shares": [...]}
-  ],
-  "erasure": {"algorithm": "reed-solomon", "k": 2, "n": 3}
+  "size": 95,
+  "created": 1701820800,
+  "modified": 1701907200,
+  "file_id": "<base64-encoded 32-byte random identifier>",
+  "inline": "<base64-encoded encrypted content>",
+  "erasure": {
+    "algorithm": "reed-solomon",
+    "k": 2,
+    "n": 3,
+    "field": "gf256"
+  }
 }
 ```
 
-Each block index chunk contains an array of block entries, stored as a separate encrypted blob. This bounds inode size regardless of file size, at the cost of one additional fetch per block index chunk during file access.
+When the `inline` field is present, the `blocks` array is omitted. The inline content is encrypted with the file's `file_key` (derived from `master_key` and `file_id`, see Section 6.1), NOT with `metadata_key`. This preserves key separation: an attacker who compromises `metadata_key` can read the inode structure (filenames, sizes, timestamps, and the opaque `inline` ciphertext) but cannot decrypt the file content without `master_key`.
+
+The inline ciphertext uses the same authenticated encryption format as block content:
+
+```
+enc_key = HKDF-Expand(file_key, "garland-v1:enc", 32)
+mac_key = HKDF-Expand(file_key, "garland-v1:mac", 32)
+nonce = random_bytes(12)
+ciphertext = ChaCha20(enc_key, nonce, file_content)
+mac = HMAC-SHA256(mac_key, nonce || ciphertext)
+inline_value = base64(nonce || ciphertext || mac)
+```
+
+Note that the block index derivation step is skipped for inline content (there is no `block_key`; `enc_key` and `mac_key` are derived directly from `file_key`). No inner padding is needed: the file size is already visible in the `size` field to anyone who can decrypt the inode with `metadata_key`.
+
+The resulting inode (containing the inline ciphertext) is then encrypted with `metadata_key` and stored through the normal inode pipeline. This produces double encryption (`file_key` inside `metadata_key`), which is a standard and safe cryptographic pattern.
+
+Implementations SHOULD inline files when the serialized inode (including inline content) fits within a single block's plaintext capacity C. Implementations MUST support reading inline inodes even if they do not write them.
 
 ---
 
 ## 8. Directory Hierarchy
 
 ### 8.1 Directories as Encrypted Blobs
+
+Garland uses a single canonical inode reference format everywhere a blob graph points to another inode: directory entries, commit roots, and any preserved historical commit references. Every inode reference MUST include enough information for an independent implementation to fetch and decode it without relying on bucket-global defaults.
+
+Single-block inode reference:
+
+```json
+{
+  "format": "single",
+  "hash": "<content hash of encrypted inode blob>",
+  "erasure": {
+    "algorithm": "reed-solomon",
+    "k": 2,
+    "n": 3,
+    "field": "gf256"
+  },
+  "shares": [
+    {"id": "<share0_sha256>", "server": "https://blossom1.example.com", "auth": "blob"},
+    {"id": "<share1_sha256>", "server": "https://blossom2.example.com", "auth": "blob"},
+    {"id": "<share2_sha256>", "server": "https://blossom3.example.com", "auth": "blob"}
+  ]
+}
+```
+
+Multi-block inode reference:
+
+```json
+{
+  "format": "multi",
+  "inode_id": "<base64-encoded 32-byte random identifier>",
+  "erasure": {
+    "algorithm": "reed-solomon",
+    "k": 2,
+    "n": 3,
+    "field": "gf256"
+  },
+  "blocks": [
+    {
+      "index": 0,
+      "hash": "<SHA-256 of canonical block payload>",
+      "shares": [
+        {"id": "<share0_sha256>", "server": "https://blossom1.example.com", "auth": "blob"},
+        {"id": "<share1_sha256>", "server": "https://blossom2.example.com", "auth": "blob"},
+        {"id": "<share2_sha256>", "server": "https://blossom3.example.com", "auth": "blob"}
+      ]
+    }
+  ]
+}
+```
 
 A directory is simply a file whose decrypted contents enumerate named entries and their corresponding inode references. After decryption, a directory blob contains:
 
@@ -444,27 +611,50 @@ A directory is simply a file whose decrypted contents enumerate named entries an
   "entries": {
     "photos": {
       "type": "directory",
-      "inode": "<content hash of photos directory inode blob>"
+      "ref": {
+        "format": "single",
+        "hash": "<content hash of photos directory inode blob>",
+        "erasure": {"algorithm": "reed-solomon", "k": 2, "n": 3, "field": "gf256"},
+        "shares": [
+          {"id": "<share0_sha256>", "server": "https://blossom1.example.com", "auth": "blob"},
+          {"id": "<share1_sha256>", "server": "https://blossom2.example.com", "auth": "blob"},
+          {"id": "<share2_sha256>", "server": "https://blossom3.example.com", "auth": "blob"}
+        ]
+      }
     },
     "documents": {
       "type": "directory",
-      "inode": "<content hash of documents directory inode blob>"
+      "ref": {
+        "format": "single",
+        "hash": "<content hash of documents directory inode blob>",
+        "erasure": {"algorithm": "reed-solomon", "k": 2, "n": 3, "field": "gf256"},
+        "shares": [...]
+      }
     },
     "notes.txt": {
       "type": "file",
-      "inode": "<content hash of notes.txt inode blob>"
+      "ref": {
+        "format": "single",
+        "hash": "<content hash of notes.txt inode blob>",
+        "erasure": {"algorithm": "reed-solomon", "k": 2, "n": 3, "field": "gf256"},
+        "shares": [...]
+      }
     }
   }
 }
 ```
 
-The client encrypts and stores directory blobs identically to file inodes: same block size, same encryption, same erasure coding. Entry names remain within the encrypted blob, invisible to servers.
+Each entry contains a `ref` object with the full inode reference. Single-block references carry the encrypted inode blob hash and share locations directly. Multi-block references carry an `inode_id`, erasure parameters, and per-block share lists. Readers MUST use the erasure parameters from the reference itself, not infer them from bucket defaults or current client configuration.
+
+Implementations SHOULD use a single bucket-wide erasure profile for ordinary operation. The per-reference `erasure` field exists for decode safety and forward compatibility, not to encourage frequent per-blob parameter changes. Reusing one profile across a bucket keeps share sizes uniform and minimizes privacy leakage from server-visible blob dimensions.
+
+The client encrypts and stores directory blobs identically to file inodes: same block size, same authenticated encryption, same erasure coding. Entry names remain within the encrypted blob, invisible to servers.
 
 ### 8.2 Merkle DAG Structure
 
-The directory hierarchy forms a Merkle Directed Acyclic Graph (DAG), a tree-like structure where each node is identified by the cryptographic hash of its contents and parent nodes include the hashes of their children. Any modification to a child changes its hash, which propagates up to the root.
+The directory hierarchy forms a Merkle Directed Acyclic Graph (DAG), a tree-like structure where authenticated references point from parent nodes to child nodes. Any modification to a child changes either the encrypted blob hash (for single-block nodes) or the ordered block metadata inside its inode reference (for multi-block nodes), which propagates upward when parents are rewritten.
 
-Each node, whether file inode or directory, is identified by the content hash of its encrypted representation.
+Single-block nodes are identified by the content hash of their encrypted representation. Multi-block nodes are identified by their full inode reference (`inode_id`, erasure parameters, and ordered block list).
 
 ```
                     ┌─────────────────┐
@@ -487,17 +677,17 @@ Each node, whether file inode or directory, is identified by the content hash of
     └───────────────┘ └───────────────┘
 ```
 
-This structure provides several important properties. Any node's hash authenticates its entire subtree: if an attacker modifies any descendant, the hashes will not match during traversal. The structure can be verified incrementally; a client can validate a path from root to a specific file without fetching the entire tree. Unchanged subtrees share storage; updating one file doesn't require re-uploading siblings.
+This structure provides several important properties. Any authenticated inode reference validates the child subtree it names: if an attacker modifies any descendant, share hashes, block hashes, or inode-reference checks will fail during traversal. The structure can be verified incrementally; a client can validate a path from root to a specific file without fetching the entire tree. Unchanged subtrees share storage; updating one file doesn't require re-uploading siblings.
 
 ### 8.3 Path Resolution
 
 To resolve a path like `/photos/image1.jpg`, the client:
 
-1. Obtains the root directory hash from the current chain head
-2. Fetches and decrypts the root directory blob
-3. Looks up "photos" in the entries, obtaining hash 0xDEF
-4. Fetches and decrypts the photos directory blob  
-5. Looks up "image1.jpg" in the entries, obtaining hash 0x789
+1. Obtains the root inode reference from the current chain head
+2. Fetches and decrypts the root directory inode from that reference
+3. Looks up `"photos"` in the entries, obtaining the child inode reference
+4. Fetches and decrypts the photos directory inode
+5. Looks up `"image1.jpg"` in the entries, obtaining the file inode reference
 6. Fetches and decrypts the image1.jpg inode
 7. Uses the inode to fetch, decode, decrypt, and reassemble the file
 
@@ -1345,6 +1535,8 @@ Significant work remains for production deployment. Payment integration, automat
 10. IETF RFC 2898. PKCS #5: Password-Based Cryptography Specification Version 2.0. https://tools.ietf.org/html/rfc2898
 
 11. BIP-39. Mnemonic code for generating deterministic keys. https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki
+
+12. IETF RFC 8785. JSON Canonicalization Scheme (JCS). https://www.rfc-editor.org/rfc/rfc8785
 
 ---
 

--- a/garland-v0.1.md
+++ b/garland-v0.1.md
@@ -208,7 +208,35 @@ P(x) = b₀ + b₁x + b₂x² + ... + b_{k-1}x^{k-1}
 
 The n shares contain the evaluations of P(x) at n distinct points. Using systematic encoding, the first k shares contain the original k pieces unchanged, followed by n - k parity shares.
 
-In practice, encoding multiplies the source vector by a k × n generator matrix (typically derived from a Vandermonde or Cauchy matrix, chosen for their guaranteed invertibility properties). The computational cost is modest: encoding a 256 KiB block completes in milliseconds.
+In practice, encoding multiplies the source vector by a k × n generator matrix derived from a Vandermonde matrix. The computational cost is modest: encoding a 256 KiB block completes in milliseconds.
+
+**Interoperability Requirements**: Two implementations using different Reed-Solomon constructions will produce different shares from identical input, breaking interoperability entirely. All Garland implementations MUST use compatible erasure coding.
+
+The reference implementation is [klauspost/reedsolomon](https://github.com/klauspost/reedsolomon) (Go) with default settings:
+
+- **Field**: GF(2^8)
+- **Generator matrix**: Vandermonde-derived (the upper k×k portion is the identity matrix; the lower (n-k)×k portion contains encoding coefficients)
+- **Encoding**: Systematic (first k shares are the original data pieces, unchanged)
+
+Compatible implementations:
+- **Go**: `klauspost/reedsolomon` with default options
+- **Rust**: `reed-solomon-erasure` crate (port of klauspost)
+
+New implementations MUST verify compatibility by generating shares for test vectors and comparing byte-for-byte against the reference. Implementations producing different shares from identical `(k, n, input)` tuples MUST NOT be deployed together.
+
+**Block size constraint**: The block size B is fixed at 262,144 bytes (256 KiB) regardless of k. This uniformity is required for privacy: if B varied by k, share sizes would reveal the erasure coding parameter to storage servers.
+
+When B is not evenly divisible by k, the encrypted block MUST be padded with zero bytes to the next multiple of k before Reed-Solomon encoding. The padding length is `(k - (B mod k)) mod k`, which is at most `k - 1` bytes. During reconstruction, after erasure decoding and concatenating the k data shares, the decoder truncates the result to exactly B bytes, discarding any RS padding.
+
+| k | B (bytes) | RS pad (bytes) | Share size (bytes) |
+|---|-----------|---------------|-------------------|
+| 2 | 262,144 | 0 | 131,072 |
+| 3 | 262,144 | 2 | 87,382 |
+| 4 | 262,144 | 0 | 65,536 |
+| 5 | 262,144 | 1 | 52,429 |
+| 6 | 262,144 | 2 | 43,691 |
+
+The share size is `(B + pad) / k`. Implementations MUST NOT vary B to avoid RS padding.
 
 ### 5.3 Decoding Process
 
@@ -231,7 +259,11 @@ The choice of n and k determines the tradeoff between storage overhead, fault to
 | 4 | 7 | 1.75× | 3 failures | 7 |
 | 6 | 9 | 1.50× | 3 failures | 9 |
 
-**Simple replication (k=1)**: When k=1, erasure coding degenerates to simple replication where each share is an identical copy of the full encrypted block. Any single server can provide the complete block with no decoding required. This configuration trades storage efficiency (n× overhead) for operational simplicity and maximum fault tolerance (survives n−1 failures). It suits users who prioritize simplicity over storage cost, or who have access to few servers. Note that with k=1, all servers store blobs with identical hashes, enabling potential cross-server correlation; with k>1, each share has a unique hash.
+**Simple replication (k=1)**: When k=1, erasure coding degenerates to simple replication. Each of the n servers stores the same encrypted block bytes. No splitting or parity generation occurs, and any single server can provide the complete block.
+
+This mode is simpler to implement and survives n - 1 server failures, but it leaks one extra fact: colluding servers can detect that identical share hashes represent replicas of the same encrypted block. Users who want the strongest cross-server unlinkability SHOULD prefer k > 1.
+
+Any single server can provide the complete block with no decoding required. This configuration trades storage efficiency (n× overhead) for operational simplicity and maximum fault tolerance (survives n−1 failures). It suits users who prioritize simplicity over storage cost, or who have access to few servers.
 
 **Erasure coding (k>1)**: For personal storage, (n=3, k=2) or (n=5, k=3) provides a reasonable balance. The former tolerates one server failure with 50% overhead; the latter tolerates two failures with 67% overhead. Users with access to more servers or heightened durability requirements may choose higher parameters.
 
@@ -260,33 +292,45 @@ nsec + passphrase (empty string default)
   │
   └─► Storage nsec (PBKDF2, see Section 6.4)
         │
-        └─► Master Key (HKDF)
+        └─► PRK (HKDF-Extract)
               │
-              ├─► Commit Key (HKDF-Expand)
-              │
-              ├─► Metadata Key (HKDF-Expand)
-              │
-              ├─► Per-Blob Auth Key (HKDF-Expand with share_id, see Section 11.2)
-              │
-              └─► Per-File Key (random, stored encrypted in inode)
+              └─► Master Key (HKDF-Expand)
                     │
-                    └─► Per-Block Key (HKDF-Expand with block index)
+                    ├─► Commit Key (HKDF-Expand)
+                    │
+                    ├─► Metadata Key (HKDF-Expand)
+                    │     │
+                    │     └─► Per-Inode Key (HKDF-Expand with inode_id, see Section 7.1)
+                    │           │
+                    │           └─► Per-Block Key (HKDF-Expand with block index)
+                    │
+                    ├─► Per-Blob Auth Key (HKDF-Expand with share_id, see Section 11.2)
+                    │
+                    └─► Per-File Key (HKDF-Expand with file_id)
+                          │
+                          └─► Per-Block Key (HKDF-Expand with block index)
 ```
 
-The master storage key is derived from the storage nsec (not the raw user nsec):
+The master storage key is derived from the storage nsec (not the raw user nsec) using the full HKDF (Extract-then-Expand) as defined in RFC 5869:
 
 ```
-master_key = HKDF-SHA256(
-    IKM = storage_nsec,
-    salt = None,
+# Step 1: Extract
+PRK = HKDF-Extract(
+    salt = 0x0000...00 (32 zero bytes),
+    IKM = storage_nsec
+)
+
+# Step 2: Expand
+master_key = HKDF-Expand(
+    PRK = PRK,
     info = "garland-v1:master",
     length = 32
 )
 ```
 
-Per RFC 5869, salt should be independent of IKM; using empty salt is explicitly permitted and avoids any dependency concerns. The storage_nsec already has high entropy from PBKDF2, so the extraction phase primarily provides domain separation via the info string. This derivation is fully deterministic: the same nsec + passphrase always produces the same master key, enabling recovery without storing additional secrets. The storage nsec derivation is described in Section 6.4.
+Per RFC 5869 Section 2.2, when salt is not provided, it defaults to a string of HashLen (32 for SHA-256) zero bytes. The storage_nsec already has high entropy from PBKDF2, so the extraction phase primarily provides domain separation. This derivation is fully deterministic: the same nsec + passphrase always produces the same master key, enabling recovery without storing additional secrets. The storage nsec derivation is described in Section 6.4.
 
-Purpose-specific keys are derived from the master key using HKDF-Expand (no additional salt needed since master_key is already a PRK):
+Purpose-specific keys are derived from the master key using HKDF-Expand only. The master_key is a 32-byte pseudorandom output of HKDF-Expand, which satisfies HKDF-Expand's input requirement of "a pseudorandom key of at least HashLen octets" (RFC 5869 Section 2.3):
 
 ```
 commit_key = HKDF-Expand(
@@ -304,9 +348,22 @@ metadata_key = HKDF-Expand(
 
 The commit key encrypts commit event content. The metadata key encrypts inodes and directory blobs. Separating these keys limits the impact of potential key compromise and clarifies the encryption scope.
 
-Each file receives a randomly generated 256-bit key at creation time. This per-file key is stored within the file's inode, encrypted with the metadata key. Random per-file keys ensure that identical files produce different ciphertexts, preventing content-based correlation.
+Single-block metadata MAY be encrypted directly under `metadata_key` for simplicity. Multi-block metadata derives a per-inode key from `metadata_key` as shown in the diagram and in Section 7.1.
 
-**File modification**: When a file is modified, the client creates a new inode with a freshly generated random file_key. The file_key is never reused across file versions. This is essential because the encryption uses a fixed zero nonce; reusing a file_key for different content would cause keystream reuse, enabling trivial plaintext recovery.
+Each file receives a randomly generated 256-bit `file_id` at creation time. This identifier is stored in plaintext within the inode and used to derive the file's encryption key:
+
+```
+file_id = random_bytes(32)
+file_key = HKDF-Expand(
+    PRK = master_key,
+    info = "garland-v1:file:" || file_id,
+    length = 32
+)
+```
+
+This derivation provides cryptographic separation between metadata and content. An attacker who compromises `metadata_key` can decrypt inodes and learn file structure, but cannot derive `file_key` without `master_key`. The `file_id` in plaintext is meaningless without `master_key`.
+
+**File modification**: When a file is modified, the client creates a new inode with a freshly generated `file_id`. This ensures each file version uses a unique `file_key`, preventing key reuse across versions.
 
 Per-block keys are derived from the file key:
 
@@ -320,19 +377,53 @@ block_key = HKDF-Expand(
 
 ### 6.2 Encryption
 
-Each block is encrypted using ChaCha20, a stream cipher widely used in the Nostr ecosystem (NIP-44) and well-supported across platforms.
+Each block is encrypted using ChaCha20 (RFC 8439, IETF variant with 96-bit nonce, initial block counter = 0) with HMAC-SHA256 authentication, following a construction similar to NIP-44. This provides both confidentiality and authentication.
+
+To maintain cryptographic key separation, each block key is split into distinct encryption and authentication sub-keys via HKDF-Expand:
+
+```
+block_key = HKDF-Expand(K_f, "garland-v1:block:" || block_index_as_u64_be, 32)
+enc_key   = HKDF-Expand(block_key, "garland-v1:enc", 32)
+mac_key   = HKDF-Expand(block_key, "garland-v1:mac", 32)
+```
 
 The encryption process for block i with file key K_f:
 
 ```
 block_key = HKDF-Expand(K_f, "garland-v1:block:" || i, 32)
-nonce = 0x000000000000000000000000  (12 zero bytes)
-ciphertext = ChaCha20(block_key, nonce, plaintext_block)
+enc_key = HKDF-Expand(block_key, "garland-v1:enc", 32)
+mac_key = HKDF-Expand(block_key, "garland-v1:mac", 32)
+nonce = random_bytes(12)
+ciphertext = ChaCha20(enc_key, nonce, plaintext_block)
+mac = HMAC-SHA256(mac_key, nonce || ciphertext)
+encrypted_block = nonce || ciphertext || mac
 ```
 
-Since each block uses a unique derived key, a fixed zero nonce is cryptographically safe: the (key, nonce) pair is never reused. This avoids 12 bytes of overhead per block.
+The encrypted block format is:
 
-Integrity is provided by the content-addressing scheme. Each share is stored and retrieved by its SHA-256 hash, and if a server returns data that doesn't match the requested hash, it is rejected. After decryption, the plaintext block hash is verified against the value stored in the inode. This layered integrity checking at the storage layer makes encryption-layer authentication unnecessary.
+```
+[nonce: 12 bytes][ciphertext: B - 44 bytes][mac: 32 bytes]
+```
+
+**Key separation**: Deriving separate `enc_key` and `mac_key` from each `block_key` avoids dual-use keying.
+
+**Random nonces**: Each block uses a freshly generated random nonce, providing defense-in-depth against implementation bugs that might cause key reuse.
+
+**Authentication**: The HMAC authenticates both the nonce and ciphertext, detecting tampering before decryption. This complements the content-addressing integrity check by catching corruption earlier.
+
+**Decryption process**:
+
+```
+nonce = encrypted_block[0:12]
+ciphertext = encrypted_block[12:-32]
+mac = encrypted_block[-32:]
+enc_key = HKDF-Expand(block_key, "garland-v1:enc", 32)
+mac_key = HKDF-Expand(block_key, "garland-v1:mac", 32)
+expected_mac = HMAC-SHA256(mac_key, nonce || ciphertext)
+if not constant_time_compare(mac, expected_mac):
+    reject("authentication failed")
+plaintext = ChaCha20(enc_key, nonce, ciphertext)
+```
 
 ### 6.3 Metadata Encryption
 
@@ -356,6 +447,27 @@ The resulting shares are indistinguishable from file data shares. See Section 14
 
 ### 6.4 Storage Identity Derivation
 
+Whenever this protocol derives a secp256k1 private key from pseudorandom bytes, implementations MUST use the following rejection-sampling procedure:
+
+```
+SECP256K1_N = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+
+function derive_secp256k1_scalar(prk: bytes[32], info: bytes) -> bytes[32]:
+    counter = 0
+    while true:
+        candidate = HKDF-Expand(
+            PRK = prk,
+            info = info || u32_be(counter),
+            length = 32
+        )
+        x = bytes_to_uint256(candidate)
+        if 0 < x < SECP256K1_N:
+            return candidate
+        counter += 1
+```
+
+Implementations MUST NOT reduce candidates modulo the curve order.
+
 The storage nsec is always derived from the user's nsec combined with a passphrase. This derivation serves two purposes: it separates the storage identity from the user's social Nostr identity, and it enables multiple independent storage buckets via different passphrases.
 
 ```
@@ -367,10 +479,11 @@ function derive_storage_nsec(nsec: bytes[32], passphrase: string) -> bytes[32]:
         iterations = 210000,
         output_length = 32
     )
-    return HMAC-SHA256(key = "garland-v1-nsec", message = nsec || stretched)
+    seed = HMAC-SHA256(key = "garland-v1-nsec", message = nsec || stretched)
+    return derive_secp256k1_scalar(seed, "garland-v1:storage-scalar")
 ```
 
-The derivation uses only primitives present in the Nostr ecosystem (HMAC-SHA256, PBKDF2, secp256k1), avoiding new dependencies. PBKDF2 (Password-Based Key Derivation Function 2) deliberately slows key derivation through repeated hashing, making brute-force attacks expensive. The identity-bound salt prevents rainbow tables across users. The 210,000 iteration count follows OWASP 2023 guidelines for PBKDF2-HMAC-SHA256. The derived output is used directly as a secp256k1 private key.
+The derivation uses only primitives present in the Nostr ecosystem (HMAC-SHA256, PBKDF2, secp256k1), avoiding new dependencies. PBKDF2 (Password-Based Key Derivation Function 2) deliberately slows key derivation through repeated hashing, making brute-force attacks expensive. The identity-bound salt prevents rainbow tables across users. The 210,000 iteration count follows OWASP 2023 guidelines for PBKDF2-HMAC-SHA256. The final rejection-sampling step guarantees a valid secp256k1 private key with deterministic behavior across implementations.
 
 **Default passphrase**: When no passphrase is specified, the empty string is used. This is not a special case; the derivation runs identically with `passphrase = ""`. The empty-string bucket serves as the default storage location.
 
@@ -908,7 +1021,7 @@ The `{sha256}` path component is the lowercase hex-encoded SHA-256 hash of the b
 
 ### 11.2 Authentication
 
-Some servers require authentication for write operations (PUT, DELETE) via a Nostr event in the Authorization header. Other servers operate openly without authentication.
+Some servers require authentication for write operations (PUT, DELETE) via a Nostr event in the Authorization header. Other servers operate openly without authentication. Share descriptors record this as `auth: "none"`.
 
 #### Per-Blob Authentication Keys
 
@@ -943,7 +1056,7 @@ The authorization event has kind 24242:
     ["x", "<sha256 of blob being uploaded>"],
     ["expiration", "1701910800"]
   ],
-  "content": "",
+  "content": "garland upload authorization",
   "sig": "<signature from per-blob key>"
 }
 ```
@@ -956,11 +1069,15 @@ With per-blob keys, each blob appears to come from a different user. Servers can
 
 For servers requiring a billing relationship or account management, users may opt into identity key mode, where all authorizations use the storage identity pubkey directly. This enables per-user quotas and billing but allows the server to correlate all blobs to the same owner.
 
-Identity key mode is selected per-server in client configuration. Users should prefer per-blob keys for privacy-focused servers and identity keys only where billing integration requires it.
+Identity key mode is selected per-server in client configuration and recorded as `auth: "identity"` in stored share descriptors. Open servers are recorded as `auth: "none"`. Users should prefer per-blob keys for privacy-focused servers and identity keys only where billing integration requires it.
 
 #### Server Verification
 
-Servers verify the signature, confirm the kind is 24242, check that the action matches the `t` tag, validate that the current time is before expiration, and verify the `x` tag matches the blob hash. Servers do not need to know which authentication mode the client uses; they simply verify valid signatures.
+Servers verify the signature, confirm the kind is 24242, check that the action matches the `t` tag, validate that the current time is before expiration, and verify the `x` tag matches the blob hash.
+
+For authenticated servers, Garland defines an additional delete-ownership rule: the upload authorization also establishes delete authority. A Garland-compatible server MUST persist the authorization pubkey used for each accepted blob hash. A later `DELETE /{sha256}` MUST be accepted only if the authorization event is signed by the same pubkey that authorized the upload, or by an account-level key explicitly configured by the server for identity-key mode. A valid signature by some unrelated pubkey is not sufficient.
+
+This rule is stricter than baseline Blossom interoperability. A generic Blossom server that does not implement Garland's delete-ownership rule is still usable as an append-only server for `PUT`, `GET`, and `HEAD`, but Garland clients MUST NOT assume that `DELETE` will work safely there. Clients SHOULD mark such servers as non-GC targets.
 
 ### 11.3 Server Responses
 
@@ -976,7 +1093,13 @@ Successful upload returns a blob descriptor:
 }
 ```
 
-The URL may differ from the upload endpoint if the server uses a CDN or different domain for retrieval.
+The `url` may differ from the upload endpoint if the server uses a CDN or different domain for retrieval.
+
+Clients MUST persist both write and read semantics in share descriptors:
+- `server`: the authenticated write/delete origin used for `PUT /upload` and `DELETE /{sha256}`
+- `url`: the absolute retrieval URL returned by the server for `GET`/`HEAD`
+
+If the returned `url` is exactly `server + "/" + sha256`, clients MAY omit `url` from stored metadata and derive it on demand. If it differs, clients MUST store it explicitly.
 
 GET requests return the raw blob bytes with appropriate headers:
 
@@ -990,16 +1113,28 @@ HEAD requests return the same headers without the body, enabling existence check
 
 ### 11.4 Server Interchangeability
 
-Blossom servers are interchangeable and fungible. A blob uploaded to server A can be retrieved from server B if server B also has it. The content hash serves as a universal identifier across all servers.
+Blossom servers are interchangeable in that any server can store and serve any blob by its content hash. However, inodes explicitly bind specific server URLs for each share:
 
-This interchangeability enables several patterns:
+```json
+{
+  "shares": [
+    {"id": "<share0_hash>", "server": "https://blossom1.example.com", "url": "https://cdn1.example.com/<share0_hash>", "auth": "blob"},
+    {"id": "<share1_hash>", "server": "https://blossom2.example.com", "auth": "blob"},
+    {"id": "<share2_hash>", "server": "https://blossom3.example.com", "auth": "blob"}
+  ]
+}
+```
 
-- **Mirroring**: Upload the same blob to multiple servers for redundancy
-- **Migration**: Move from one server to another by re-uploading
-- **CDN integration**: Servers can replicate blobs to edge locations
-- **Opportunistic caching**: Clients can check multiple servers and use whichever responds fastest
+Clients fetch shares from `url` when present, otherwise from `server/{id}`. Uploads and deletes always target the `server` origin. There is no automatic discovery mechanism for finding alternative servers that may also host a given share.
 
-The system's erasure coding distributes shares across servers, so migration requires uploading only shares to replacement servers, not the full reconstructed blob.
+In practice, "interchangeability" means:
+
+- **Flexible fetching**: Clients can choose which k of n listed servers to fetch from
+- **Repair via replacement**: Failed servers can be replaced by uploading shares to new servers and updating the inode
+- **Migration**: Move from one server to another by re-uploading shares and updating references
+- **CDN integration**: Servers can replicate blobs to edge locations transparently
+
+The system does not include automatic discovery of alternative servers hosting a given share.
 
 ---
 
@@ -1540,14 +1675,109 @@ Significant work remains for production deployment. Payment integration, automat
 
 ---
 
-## Appendix: Recommended Parameters
+## Appendix A: Recommended Parameters
 
 | Parameter | Value | Rationale |
 |-----------|-------|-----------|
-| Block size | 256 KiB | Balance between padding overhead and chunking granularity |
+| Block size (B) | 262,144 bytes (256 KiB) | Fixed for all k values; balance between padding overhead and chunking granularity |
+| Plaintext frame (C) | B - 44 = 262,100 bytes | Reserves space for 12-byte nonce + 32-byte MAC |
+| Content capacity (C_eff) | C - 4 = 262,096 bytes | Reserves 4 bytes for length prefix in every block |
 | Erasure coding | (n=5, k=3) | Tolerates 2 failures with 67% overhead |
-| Encryption | ChaCha20 | Simple, fast, integrity via content addressing |
+| Encryption | ChaCha20 (RFC 8439) + HMAC-SHA256 | IETF variant, 96-bit nonce, NIP-44 aligned |
 | Key derivation | HKDF-SHA256 | Standard, widely implemented |
 | Commit relays | 5+ | Ensures retrievability despite relay failures |
 | Verification | Weekly | Balances failure detection and bandwidth |
 | Passphrase KDF | PBKDF2, 210k iterations | OWASP 2023 aligned, ~0.5-1s derivation |
+
+---
+
+## Appendix B: Reed-Solomon Test Vectors
+
+All implementations MUST verify compatibility against these test vectors before deployment. These vectors were generated with `github.com/klauspost/reedsolomon` v1.12.4 using default settings (systematic encoding over GF(2^8)).
+
+The common test input is the 12-byte block:
+
+```
+Input (hex): 000102030405060708090a0b
+```
+
+### (k=1, n=3)
+
+```
+Share 0: 000102030405060708090a0b
+Share 1: 000102030405060708090a0b
+Share 2: 000102030405060708090a0b
+```
+
+Reconstruction check: any 1 share reproduces the input block exactly.
+
+### (k=2, n=3)
+
+```
+Share 0: 000102030405
+Share 1: 060708090a0b
+Share 2: 0c0d16171819
+```
+
+Reconstruction check: shares {0,2} and shares {1,2} both reconstruct `000102030405060708090a0b`.
+
+### (k=3, n=5)
+
+```
+Share 0: 00010203
+Share 1: 04050607
+Share 2: 08090a0b
+Share 3: 0c0d0e0f
+Share 4: 10111213
+```
+
+Reconstruction check: shares {0,3,4} reconstruct `000102030405060708090a0b`.
+
+### (k=4, n=6)
+
+```
+Share 0: 000102
+Share 1: 030405
+Share 2: 060708
+Share 3: 090a0b
+Share 4: fc9d56
+Share 5: d7a849
+```
+
+Reconstruction check: shares {0,2,4,5} reconstruct `000102030405060708090a0b`.
+
+### (k=4, n=7)
+
+```
+Share 0: 000102
+Share 1: 030405
+Share 2: 060708
+Share 3: 090a0b
+Share 4: fc9d56
+Share 5: d7a849
+Share 6: 9adb7c
+```
+
+Reconstruction check: shares {1,3,4,6} reconstruct `000102030405060708090a0b`.
+
+### (k=6, n=9)
+
+```
+Share 0: 0001
+Share 1: 0203
+Share 2: 0405
+Share 3: 0607
+Share 4: 0809
+Share 5: 0a0b
+Share 6: 0c0d
+Share 7: 0e0f
+Share 8: 1011
+```
+
+Reconstruction check: shares {0,2,4,6,7,8} reconstruct `000102030405060708090a0b`.
+
+Implementations SHOULD also publish machine-readable test vectors covering:
+1. RS padding when `B mod k != 0`
+2. Block framing and canonical payload hashes
+3. Storage identity derivation and secp256k1 scalar rejection sampling
+4. Commit encryption and inode-reference serialization


### PR DESCRIPTION
## Summary
- lock down Reed-Solomon interoperability, fixed block sizing, and published coding parameters
- define the HKDF, file-key, authentication-key, and ChaCha20/HMAC split-key rules needed for compatible implementations
- clarify Blossom transport semantics, including read/write origins and Garland's delete-ownership expectations