### PR TITLE
Harden recovery, verification, and garbage collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,15 +59,15 @@ See [garland-v0.md](garland-v0.md) and [garland-v0.1.md](garland-v0.1.md) for th
 
 **Commit Ordering**
 - *v0:* Replaceable event with implicit ordering
-- *v0.1:* No sequence counter, head discovery via `limit=1` relay query (reverse chronological), chain traversal via `prev` tags for full history
+- *v0.1:* Encrypted commit chain with monotonic `seq`, `created_at` used only as a relay hint, full traversal required for fork-safe head selection
 
 **Encryption**
 - *v0:* ChaCha20-Poly1305 or AES-GCM (underspecified)
-- *v0.1:* ChaCha20 with fixed zero nonce and unique per-block keys (HKDF-Expand), integrity via content addressing (SHA-256 share IDs + plaintext block hashes in inodes)
+- *v0.1:* ChaCha20 (RFC 8439) with random nonces, HMAC-SHA256, split enc/mac keys, integrity via share IDs plus canonical block-payload hashes
 
 **Key Derivation**
 - *v0:* Generic KDF, underspecified
-- *v0.1:* HKDF-SHA256 with empty salt for master key, HKDF-Expand for derived keys, versioned info strings (garland-v1:*), file_key must be regenerated on modification
+- *v0.1:* HKDF-SHA256 with explicit Extract/Expand stages, versioned info strings, derived per-file keys, and deterministic secp256k1 scalar rejection sampling for auth/storage keys
 
 **Relay Discovery**
 - *v0:* Unspecified, assumed NIP-65 or manual

--- a/garland-v0.1.md
+++ b/garland-v0.1.md
@@ -105,28 +105,55 @@ When writing a file, the client divides data into fixed-size blocks, encrypts ea
 
 When reading a file, the client traverses from the current chain head through the directory structure to locate the target inode, fetches any k of the n shares for each block, decodes and decrypts the blocks, and reassembles the original file.
 
+### 3.1 Serialization and Wire Formats
+
+All JSON structures in this protocol (inodes, directory entries, commit content) MUST be serialized using RFC 8785 JSON Canonicalization Scheme (JCS) before hashing, signing, or encrypting them. Deterministic serialization is required for content-addressing: two implementations encoding the same logical structure must produce identical bytes.
+
+Implementations MUST NOT rely on insertion order, runtime hash map ordering, platform-specific floating point formatting, ad hoc whitespace rules, or any other non-canonical JSON behavior. Object member ordering, string escaping, Unicode handling, and number rendering MUST follow RFC 8785 exactly.
+
+**Encoding conventions:**
+- **SHA-256 hashes** (share IDs, content hashes): lowercase hex-encoded strings (64 characters)
+- **Binary data** (file_id, inode_id, nonces): standard base64 with padding (RFC 4648 Section 4)
+- **Integers in binary fields** (content_length, block_index): big-endian unsigned
+- **Integers in JSON**: decimal (standard JSON number), but values MUST remain within the I-JSON safe integer range `0 <= x <= 2^53 - 1`
+- **Strings**: UTF-8
+
+These conventions apply throughout the spec. When examples show `<content hash>` or `<share_hash>`, these are lowercase hex strings. When examples show `<base64-encoded 32-byte ...>`, these use standard base64 with `=` padding.
+
 ---
 
 ## 4. Block Layer
 
 ### 4.1 Fixed-Size Blocks
 
-All data entering the system is divided into fixed-size blocks before any cryptographic processing. The block size B is a system parameter, typically 256 KiB (262,144 bytes), though implementations may support alternative sizes for specific use cases.
+All data entering the system is divided into fixed-size blocks before any cryptographic processing. The block size B is a system parameter, fixed at 262,144 bytes (256 KiB). B refers to the total encrypted block size; the plaintext frame per block is `C = B - 44` bytes (262,100 bytes) to accommodate the 12-byte nonce and 32-byte MAC (see Section 6.2).
 
-For a file of size S bytes, the number of blocks is:
-
-```
-N_blocks = ⌈S / B⌉
-```
-
-The final block is padded to exactly B bytes using a length-prefixed padding scheme. Only the final block includes a length prefix: the first four bytes encode the actual content length as a big-endian 32-bit unsigned integer, followed by the content bytes, followed by zero bytes to fill the block:
+Every block uses a uniform length-prefixed format. The first four bytes of each plaintext frame encode the content length as a big-endian 32-bit unsigned integer, followed by the content bytes, followed by random padding to fill the frame:
 
 ```
-Non-final blocks: [content: B bytes]
-Final block:      [content_length: u32_be][content: content_length bytes][padding: zeros]
+Every block: [content_length: u32_be][content: content_length bytes][padding: random bytes to C total]
 ```
 
-This scheme enables unambiguous removal of padding during reconstruction. For the final block, content_length contains `S mod B`. A value of 0 indicates the final block is completely full, meaning the file size is an exact multiple of B. Non-final blocks contain exactly B bytes of content with no overhead.
+The effective content capacity per block is `C_eff = C - 4 = 262,096` bytes. For a file of size S bytes, the number of blocks is:
+
+```
+C = B - 44 = 262,100  (plaintext frame per block)
+C_eff = C - 4 = 262,096  (content capacity per block, after 4-byte length prefix)
+N_blocks = ⌈S / C_eff⌉   (for S > 0; N_blocks = 1 for S = 0)
+```
+
+**content_length semantics**: Each block's `content_length` field stores the number of content bytes in that block:
+
+- **Non-final blocks**: `content_length = C_eff` (the block is completely full of content after the 4-byte prefix, with zero padding bytes)
+- **Final block where `S mod C_eff > 0`**: `content_length = S mod C_eff`
+- **Final block where `S mod C_eff == 0` and `S > 0`**: `content_length = C_eff` (block is full)
+- **Empty file (S = 0)**: a single block with `content_length = 0` (4-byte prefix, then C - 4 bytes of random padding)
+
+The uniform format means every block is parsed identically: read 4-byte prefix, extract `content_length` bytes of content, discard the rest as padding. This eliminates the need to distinguish "final" from "non-final" blocks during decoding -- the only special handling is that the last block's `content_length` may be less than `C_eff`.
+
+The 4-byte-per-block overhead is negligible compared to the padding overhead already inherent in fixed-size blocks.
+
+The padding bytes MUST be randomly generated, not zeros. Random padding avoids known-plaintext at predictable locations within blocks. Since the padding is discarded during reconstruction (the decoder reads exactly `content_length` bytes after the prefix), the random bytes need not be reproducible.
 
 ### 4.2 Privacy Through Uniformity
 
@@ -309,14 +336,21 @@ Integrity is provided by the content-addressing scheme. Each share is stored and
 
 ### 6.3 Metadata Encryption
 
-File inodes and directory entries contain sensitive metadata: filenames, sizes, timestamps, and structural relationships. The client encrypts this metadata using the metadata key derived from the master key.
+File inodes and directory entries contain sensitive metadata: filenames, sizes, timestamps, and structural relationships. The client encrypts this metadata using the metadata key derived from the master key, with the same authenticated framing model used for file blocks.
 
-When storing an inode or directory, the client:
-1. Serializes the structure to JSON
-2. Pads to the fixed block size (256 KiB)
-3. Encrypts using ChaCha20 with the metadata key
-4. Erasure-codes the encrypted block into n shares
-5. Uploads shares to n servers
+When storing a single-block inode or directory, the client:
+1. Serializes the structure to RFC 8785 JCS JSON bytes
+2. Verifies that the serialized length is at most `C_eff = C - 4` bytes
+3. Frames the plaintext exactly as `[content_length: u32_be] || content || random_padding` to total `C = B - 44` bytes, using the same block format as Section 4.1
+4. Derives `enc_key = HKDF-Expand(metadata_key, "garland-v1:enc", 32)` and `mac_key = HKDF-Expand(metadata_key, "garland-v1:mac", 32)`
+5. Generates a random 12-byte nonce
+6. Encrypts using ChaCha20 with `enc_key` and nonce
+7. Computes `HMAC-SHA256(mac_key, nonce || ciphertext)`
+8. Prepends nonce and appends MAC to form a B-byte encrypted block
+9. Erasure-codes the encrypted block into n shares
+10. Uploads shares to n servers
+
+The nonce is embedded in the encrypted block, not stored separately in the parent reference. To decrypt, the client fetches the shares, reconstructs the block, extracts the nonce from the first 12 bytes, verifies the MAC, decrypts, then parses the Section 4.1 frame to recover the JSON bytes.
 
 The resulting shares are indistinguishable from file data shares. See Section 14 for detailed privacy analysis.
 
@@ -367,24 +401,24 @@ An inode contains all information necessary to reconstruct a file. After decrypt
   "size": 10485760,
   "created": 1701820800,
   "modified": 1701907200,
-  "key": "<base64-encoded encrypted file key>",
+  "file_id": "<base64-encoded 32-byte random identifier>",
   "blocks": [
     {
       "index": 0,
-      "hash": "<SHA-256 of plaintext block for integrity verification>",
+      "hash": "<SHA-256 of canonical block payload for integrity verification>",
       "shares": [
-        {"id": "<share0_sha256>", "server": "https://blossom1.example.com"},
-        {"id": "<share1_sha256>", "server": "https://blossom2.example.com"},
-        {"id": "<share2_sha256>", "server": "https://blossom3.example.com"}
+        {"id": "<share0_sha256>", "server": "https://blossom1.example.com", "auth": "blob"},
+        {"id": "<share1_sha256>", "server": "https://blossom2.example.com", "auth": "blob"},
+        {"id": "<share2_sha256>", "server": "https://blossom3.example.com", "auth": "blob"}
       ]
     },
     {
       "index": 1,
-      "hash": "<SHA-256 of plaintext block>",
+      "hash": "<SHA-256 of canonical block payload>",
       "shares": [
-        {"id": "<share0_sha256>", "server": "https://blossom1.example.com"},
-        {"id": "<share1_sha256>", "server": "https://blossom2.example.com"},
-        {"id": "<share2_sha256>", "server": "https://blossom3.example.com"}
+        {"id": "<share0_sha256>", "server": "https://blossom1.example.com", "auth": "blob"},
+        {"id": "<share1_sha256>", "server": "https://blossom2.example.com", "auth": "blob"},
+        {"id": "<share2_sha256>", "server": "https://blossom3.example.com", "auth": "blob"}
       ]
     }
   ],
@@ -397,41 +431,174 @@ An inode contains all information necessary to reconstruct a file. After decrypt
 }
 ```
 
-The `key` field contains the per-file encryption key, encrypted with the metadata key. File content is encrypted to the file key, and the file key is encrypted to the metadata key. This hierarchy enables recovery from nsec + passphrase while keeping file keys isolated.
+The `file_id` field contains a randomly generated 32-byte identifier used to derive the file's encryption key (see Section 6.1). The file key is derived as `HKDF-Expand(master_key, "garland-v1:file:" || file_id, 32)`. This identifier is stored in plaintext within the encrypted inode; an attacker who compromises only `metadata_key` can read the `file_id` but cannot derive the file key without `master_key`.
 
-The `hash` field in each block entry contains the SHA-256 hash of the plaintext block before encryption. This enables integrity verification after decryption: if the decrypted block's hash doesn't match, either the ciphertext was corrupted, the wrong key was used, or the inode itself is corrupt.
+The `hash` field in each block entry contains the SHA-256 hash of the canonical block payload before random padding is added. For file content blocks, the payload is `payload = [content_length: u32_be] || content`, where `content` has exactly `content_length` bytes. Random padding bytes are excluded from this hash because they are discarded during decoding and need not be reproduced during repair. This enables integrity verification after decryption: if the decrypted block's canonical payload hash doesn't match, either the ciphertext was corrupted, the wrong key was used, or the inode itself is corrupt.
 
 The `shares` array is ordered by share index (0 to n-1). The array position determines the share index, which is required for erasure decoding. During reconstruction, the client fetches shares from their listed servers, tracking which indices were successfully retrieved. Once k shares are obtained, decoding can proceed. Storing share indices in the inode (rather than embedding them in share data) provides better privacy: servers cannot determine a share's position in the erasure scheme.
 
+Each share descriptor contains:
+- `id`: lowercase hex SHA-256 of the stored share bytes
+- `server`: absolute HTTPS base URL used for authenticated `PUT` and `DELETE` requests
+- `url`: optional absolute retrieval URL used for `GET` and `HEAD`; if omitted, clients derive it as `server + "/" + id`
+- `auth`: authentication mode used for writes to that server: `"blob"` (per-blob key), `"identity"` (storage identity key), or `"none"` (server accepts unauthenticated writes)
+
+The `auth` field is required for interoperable deletion and repair. The optional `url` field is required whenever the server returns a retrieval endpoint on a different origin than the write endpoint. Recovery clients MUST use `url` for reads when present, and MUST use `server` plus `auth` for uploads, repairs, and deletions.
+
 The client stores inodes as blobs using the same pipeline: serialize, pad, encrypt, erasure-code, and distribute. The resulting structure's content hash forms a node in the Merkle DAG.
 
-### 7.1 Large File Inodes
+### 7.1 Large Inodes
 
-Files with many blocks may produce inodes exceeding the standard block size. With (n=5, k=3) erasure coding, each block entry requires approximately 500 bytes for share IDs and server URLs. A file with 500,000 blocks would generate a ~250 MB inode, far exceeding the 256 KiB block limit.
+Any inode (file or directory) may exceed the plaintext capacity C when serialized. With (n=5, k=3) erasure coding, each block entry requires approximately 500 bytes for share IDs and server URLs. A file with 500,000 blocks or a directory with thousands of entries could exceed the block size limit.
 
-For files exceeding approximately 500 blocks, the inode uses an indirect block structure:
+When an inode exceeds C bytes, it is stored as multiple blocks using the same framing and hashing rules as file content:
+
+1. Serialize the inode to JSON
+2. Split the serialized bytes into payload chunks of at most `C_eff` bytes, then frame each chunk as `[content_length || content || random_padding]` per Section 4.1
+3. Encrypt each block with a key derived from a single `inode_id`
+4. Erasure-code and upload each encrypted block
+5. The parent reference includes the `inode_id` and block list
+
+A multi-block inode reference in a directory entry:
+
+```json
+{
+  "photos": {
+    "type": "directory",
+    "ref": {
+      "format": "multi",
+      "inode_id": "<base64-encoded 32-byte random identifier>",
+      "erasure": {"algorithm": "reed-solomon", "k": 2, "n": 3, "field": "gf256"},
+      "blocks": [
+        {
+          "index": 0,
+          "hash": "<SHA-256 of canonical block payload>",
+          "shares": [
+            {"id": "<share0_sha256>", "server": "https://blossom1.example.com", "auth": "blob"},
+            {"id": "<share1_sha256>", "server": "https://blossom2.example.com", "auth": "blob"},
+            {"id": "<share2_sha256>", "server": "https://blossom3.example.com", "auth": "blob"}
+          ]
+        },
+        {
+          "index": 1,
+          "hash": "<SHA-256 of canonical block payload>",
+          "shares": [...]
+        }
+      ]
+    }
+  }
+}
+```
+
+The `inode_id` inside a multi-block inode reference serves the same purpose as `file_id` for file content, enabling deterministic key derivation for multi-block data:
+
+```
+inode_key = HKDF-Expand(metadata_key, "garland-v1:inode:" || inode_id, 32)
+block_key = HKDF-Expand(inode_key, "garland-v1:block:" || block_index_as_u64_be, 32)
+```
+
+Each block is then encrypted using the standard enc/mac key split: derive `enc_key` and `mac_key` from `block_key` via HKDF-Expand (Section 6.2), then encrypt with ChaCha20 and authenticate with HMAC-SHA256 using a random nonce. The `hash` field for each large-inode block follows the same canonical-payload rule as file blocks: `SHA256([content_length: u32_be] || content)`.
+
+For single-block inodes (the common case), the inode is encrypted directly with `metadata_key` and the nonce is embedded in the encrypted block. The plaintext still uses the Section 4.1 framed block format with `C_eff` content capacity. Implementations should use this simpler approach when the serialized inode fits in one block.
+
+This unified approach means the same chunking mechanism handles large files, large directories, and any future large metadata. Implementations use one code path for all cases.
+
+### 7.2 Inline Small Files
+
+Files below a configurable size threshold (default: 4 KiB) MAY be stored inline within their inode, avoiding the overhead of a separate block pipeline. A 100-byte file stored as a full block requires B bytes of encrypted storage plus n shares of size B/k each -- hundreds of kilobytes for a few bytes of content. Inlining eliminates this waste.
+
+An inline inode stores the encrypted file content directly:
 
 ```json
 {
   "version": 1,
   "type": "file",
-  "size": 137438953472,
-  "indirect": true,
-  "block_index": [
-    {"hash": "<content hash of block index chunk 0>", "shares": [...]},
-    {"hash": "<content hash of block index chunk 1>", "shares": [...]}
-  ],
-  "erasure": {"algorithm": "reed-solomon", "k": 2, "n": 3}
+  "size": 95,
+  "created": 1701820800,
+  "modified": 1701907200,
+  "file_id": "<base64-encoded 32-byte random identifier>",
+  "inline": "<base64-encoded encrypted content>",
+  "erasure": {
+    "algorithm": "reed-solomon",
+    "k": 2,
+    "n": 3,
+    "field": "gf256"
+  }
 }
 ```
 
-Each block index chunk contains an array of block entries, stored as a separate encrypted blob. This bounds inode size regardless of file size, at the cost of one additional fetch per block index chunk during file access.
+When the `inline` field is present, the `blocks` array is omitted. The inline content is encrypted with the file's `file_key` (derived from `master_key` and `file_id`, see Section 6.1), NOT with `metadata_key`. This preserves key separation: an attacker who compromises `metadata_key` can read the inode structure (filenames, sizes, timestamps, and the opaque `inline` ciphertext) but cannot decrypt the file content without `master_key`.
+
+The inline ciphertext uses the same authenticated encryption format as block content:
+
+```
+enc_key = HKDF-Expand(file_key, "garland-v1:enc", 32)
+mac_key = HKDF-Expand(file_key, "garland-v1:mac", 32)
+nonce = random_bytes(12)
+ciphertext = ChaCha20(enc_key, nonce, file_content)
+mac = HMAC-SHA256(mac_key, nonce || ciphertext)
+inline_value = base64(nonce || ciphertext || mac)
+```
+
+Note that the block index derivation step is skipped for inline content (there is no `block_key`; `enc_key` and `mac_key` are derived directly from `file_key`). No inner padding is needed: the file size is already visible in the `size` field to anyone who can decrypt the inode with `metadata_key`.
+
+The resulting inode (containing the inline ciphertext) is then encrypted with `metadata_key` and stored through the normal inode pipeline. This produces double encryption (`file_key` inside `metadata_key`), which is a standard and safe cryptographic pattern.
+
+Implementations SHOULD inline files when the serialized inode (including inline content) fits within a single block's plaintext capacity C. Implementations MUST support reading inline inodes even if they do not write them.
 
 ---
 
 ## 8. Directory Hierarchy
 
 ### 8.1 Directories as Encrypted Blobs
+
+Garland uses a single canonical inode reference format everywhere a blob graph points to another inode: directory entries, commit roots, and any preserved historical commit references. Every inode reference MUST include enough information for an independent implementation to fetch and decode it without relying on bucket-global defaults.
+
+Single-block inode reference:
+
+```json
+{
+  "format": "single",
+  "hash": "<content hash of encrypted inode blob>",
+  "erasure": {
+    "algorithm": "reed-solomon",
+    "k": 2,
+    "n": 3,
+    "field": "gf256"
+  },
+  "shares": [
+    {"id": "<share0_sha256>", "server": "https://blossom1.example.com", "auth": "blob"},
+    {"id": "<share1_sha256>", "server": "https://blossom2.example.com", "auth": "blob"},
+    {"id": "<share2_sha256>", "server": "https://blossom3.example.com", "auth": "blob"}
+  ]
+}
+```
+
+Multi-block inode reference:
+
+```json
+{
+  "format": "multi",
+  "inode_id": "<base64-encoded 32-byte random identifier>",
+  "erasure": {
+    "algorithm": "reed-solomon",
+    "k": 2,
+    "n": 3,
+    "field": "gf256"
+  },
+  "blocks": [
+    {
+      "index": 0,
+      "hash": "<SHA-256 of canonical block payload>",
+      "shares": [
+        {"id": "<share0_sha256>", "server": "https://blossom1.example.com", "auth": "blob"},
+        {"id": "<share1_sha256>", "server": "https://blossom2.example.com", "auth": "blob"},
+        {"id": "<share2_sha256>", "server": "https://blossom3.example.com", "auth": "blob"}
+      ]
+    }
+  ]
+}
+```
 
 A directory is simply a file whose decrypted contents enumerate named entries and their corresponding inode references. After decryption, a directory blob contains:
 
@@ -444,27 +611,50 @@ A directory is simply a file whose decrypted contents enumerate named entries an
   "entries": {
     "photos": {
       "type": "directory",
-      "inode": "<content hash of photos directory inode blob>"
+      "ref": {
+        "format": "single",
+        "hash": "<content hash of photos directory inode blob>",
+        "erasure": {"algorithm": "reed-solomon", "k": 2, "n": 3, "field": "gf256"},
+        "shares": [
+          {"id": "<share0_sha256>", "server": "https://blossom1.example.com", "auth": "blob"},
+          {"id": "<share1_sha256>", "server": "https://blossom2.example.com", "auth": "blob"},
+          {"id": "<share2_sha256>", "server": "https://blossom3.example.com", "auth": "blob"}
+        ]
+      }
     },
     "documents": {
       "type": "directory",
-      "inode": "<content hash of documents directory inode blob>"
+      "ref": {
+        "format": "single",
+        "hash": "<content hash of documents directory inode blob>",
+        "erasure": {"algorithm": "reed-solomon", "k": 2, "n": 3, "field": "gf256"},
+        "shares": [...]
+      }
     },
     "notes.txt": {
       "type": "file",
-      "inode": "<content hash of notes.txt inode blob>"
+      "ref": {
+        "format": "single",
+        "hash": "<content hash of notes.txt inode blob>",
+        "erasure": {"algorithm": "reed-solomon", "k": 2, "n": 3, "field": "gf256"},
+        "shares": [...]
+      }
     }
   }
 }
 ```
 
-The client encrypts and stores directory blobs identically to file inodes: same block size, same encryption, same erasure coding. Entry names remain within the encrypted blob, invisible to servers.
+Each entry contains a `ref` object with the full inode reference. Single-block references carry the encrypted inode blob hash and share locations directly. Multi-block references carry an `inode_id`, erasure parameters, and per-block share lists. Readers MUST use the erasure parameters from the reference itself, not infer them from bucket defaults or current client configuration.
+
+Implementations SHOULD use a single bucket-wide erasure profile for ordinary operation. The per-reference `erasure` field exists for decode safety and forward compatibility, not to encourage frequent per-blob parameter changes. Reusing one profile across a bucket keeps share sizes uniform and minimizes privacy leakage from server-visible blob dimensions.
+
+The client encrypts and stores directory blobs identically to file inodes: same block size, same authenticated encryption, same erasure coding. Entry names remain within the encrypted blob, invisible to servers.
 
 ### 8.2 Merkle DAG Structure
 
-The directory hierarchy forms a Merkle Directed Acyclic Graph (DAG), a tree-like structure where each node is identified by the cryptographic hash of its contents and parent nodes include the hashes of their children. Any modification to a child changes its hash, which propagates up to the root.
+The directory hierarchy forms a Merkle Directed Acyclic Graph (DAG), a tree-like structure where authenticated references point from parent nodes to child nodes. Any modification to a child changes either the encrypted blob hash (for single-block nodes) or the ordered block metadata inside its inode reference (for multi-block nodes), which propagates upward when parents are rewritten.
 
-Each node, whether file inode or directory, is identified by the content hash of its encrypted representation.
+Single-block nodes are identified by the content hash of their encrypted representation. Multi-block nodes are identified by their full inode reference (`inode_id`, erasure parameters, and ordered block list).
 
 ```
                     ┌─────────────────┐
@@ -487,17 +677,17 @@ Each node, whether file inode or directory, is identified by the content hash of
     └───────────────┘ └───────────────┘
 ```
 
-This structure provides several important properties. Any node's hash authenticates its entire subtree: if an attacker modifies any descendant, the hashes will not match during traversal. The structure can be verified incrementally; a client can validate a path from root to a specific file without fetching the entire tree. Unchanged subtrees share storage; updating one file doesn't require re-uploading siblings.
+This structure provides several important properties. Any authenticated inode reference validates the child subtree it names: if an attacker modifies any descendant, share hashes, block hashes, or inode-reference checks will fail during traversal. The structure can be verified incrementally; a client can validate a path from root to a specific file without fetching the entire tree. Unchanged subtrees share storage; updating one file doesn't require re-uploading siblings.
 
 ### 8.3 Path Resolution
 
 To resolve a path like `/photos/image1.jpg`, the client:
 
-1. Obtains the root directory hash from the current chain head
-2. Fetches and decrypts the root directory blob
-3. Looks up "photos" in the entries, obtaining hash 0xDEF
-4. Fetches and decrypts the photos directory blob  
-5. Looks up "image1.jpg" in the entries, obtaining hash 0x789
+1. Obtains the root inode reference from the current chain head
+2. Fetches and decrypts the root directory inode from that reference
+3. Looks up `"photos"` in the entries, obtaining the child inode reference
+4. Fetches and decrypts the photos directory inode
+5. Looks up `"image1.jpg"` in the entries, obtaining the file inode reference
 6. Fetches and decrypts the image1.jpg inode
 7. Uses the inode to fetch, decode, decrypt, and reassemble the file
 
@@ -1345,6 +1535,8 @@ Significant work remains for production deployment. Payment integration, automat
 10. IETF RFC 2898. PKCS #5: Password-Based Cryptography Specification Version 2.0. https://tools.ietf.org/html/rfc2898
 
 11. BIP-39. Mnemonic code for generating deterministic keys. https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki
+
+12. IETF RFC 8785. JSON Canonicalization Scheme (JCS). https://www.rfc-editor.org/rfc/rfc8785
 
 ---
 

--- a/garland-v0.1.md
+++ b/garland-v0.1.md
@@ -208,7 +208,35 @@ P(x) = b₀ + b₁x + b₂x² + ... + b_{k-1}x^{k-1}
 
 The n shares contain the evaluations of P(x) at n distinct points. Using systematic encoding, the first k shares contain the original k pieces unchanged, followed by n - k parity shares.
 
-In practice, encoding multiplies the source vector by a k × n generator matrix (typically derived from a Vandermonde or Cauchy matrix, chosen for their guaranteed invertibility properties). The computational cost is modest: encoding a 256 KiB block completes in milliseconds.
+In practice, encoding multiplies the source vector by a k × n generator matrix derived from a Vandermonde matrix. The computational cost is modest: encoding a 256 KiB block completes in milliseconds.
+
+**Interoperability Requirements**: Two implementations using different Reed-Solomon constructions will produce different shares from identical input, breaking interoperability entirely. All Garland implementations MUST use compatible erasure coding.
+
+The reference implementation is [klauspost/reedsolomon](https://github.com/klauspost/reedsolomon) (Go) with default settings:
+
+- **Field**: GF(2^8)
+- **Generator matrix**: Vandermonde-derived (the upper k×k portion is the identity matrix; the lower (n-k)×k portion contains encoding coefficients)
+- **Encoding**: Systematic (first k shares are the original data pieces, unchanged)
+
+Compatible implementations:
+- **Go**: `klauspost/reedsolomon` with default options
+- **Rust**: `reed-solomon-erasure` crate (port of klauspost)
+
+New implementations MUST verify compatibility by generating shares for test vectors and comparing byte-for-byte against the reference. Implementations producing different shares from identical `(k, n, input)` tuples MUST NOT be deployed together.
+
+**Block size constraint**: The block size B is fixed at 262,144 bytes (256 KiB) regardless of k. This uniformity is required for privacy: if B varied by k, share sizes would reveal the erasure coding parameter to storage servers.
+
+When B is not evenly divisible by k, the encrypted block MUST be padded with zero bytes to the next multiple of k before Reed-Solomon encoding. The padding length is `(k - (B mod k)) mod k`, which is at most `k - 1` bytes. During reconstruction, after erasure decoding and concatenating the k data shares, the decoder truncates the result to exactly B bytes, discarding any RS padding.
+
+| k | B (bytes) | RS pad (bytes) | Share size (bytes) |
+|---|-----------|---------------|-------------------|
+| 2 | 262,144 | 0 | 131,072 |
+| 3 | 262,144 | 2 | 87,382 |
+| 4 | 262,144 | 0 | 65,536 |
+| 5 | 262,144 | 1 | 52,429 |
+| 6 | 262,144 | 2 | 43,691 |
+
+The share size is `(B + pad) / k`. Implementations MUST NOT vary B to avoid RS padding.
 
 ### 5.3 Decoding Process
 
@@ -231,7 +259,11 @@ The choice of n and k determines the tradeoff between storage overhead, fault to
 | 4 | 7 | 1.75× | 3 failures | 7 |
 | 6 | 9 | 1.50× | 3 failures | 9 |
 
-**Simple replication (k=1)**: When k=1, erasure coding degenerates to simple replication where each share is an identical copy of the full encrypted block. Any single server can provide the complete block with no decoding required. This configuration trades storage efficiency (n× overhead) for operational simplicity and maximum fault tolerance (survives n−1 failures). It suits users who prioritize simplicity over storage cost, or who have access to few servers. Note that with k=1, all servers store blobs with identical hashes, enabling potential cross-server correlation; with k>1, each share has a unique hash.
+**Simple replication (k=1)**: When k=1, erasure coding degenerates to simple replication. Each of the n servers stores the same encrypted block bytes. No splitting or parity generation occurs, and any single server can provide the complete block.
+
+This mode is simpler to implement and survives n - 1 server failures, but it leaks one extra fact: colluding servers can detect that identical share hashes represent replicas of the same encrypted block. Users who want the strongest cross-server unlinkability SHOULD prefer k > 1.
+
+Any single server can provide the complete block with no decoding required. This configuration trades storage efficiency (n× overhead) for operational simplicity and maximum fault tolerance (survives n−1 failures). It suits users who prioritize simplicity over storage cost, or who have access to few servers.
 
 **Erasure coding (k>1)**: For personal storage, (n=3, k=2) or (n=5, k=3) provides a reasonable balance. The former tolerates one server failure with 50% overhead; the latter tolerates two failures with 67% overhead. Users with access to more servers or heightened durability requirements may choose higher parameters.
 
@@ -260,33 +292,45 @@ nsec + passphrase (empty string default)
   │
   └─► Storage nsec (PBKDF2, see Section 6.4)
         │
-        └─► Master Key (HKDF)
+        └─► PRK (HKDF-Extract)
               │
-              ├─► Commit Key (HKDF-Expand)
-              │
-              ├─► Metadata Key (HKDF-Expand)
-              │
-              ├─► Per-Blob Auth Key (HKDF-Expand with share_id, see Section 11.2)
-              │
-              └─► Per-File Key (random, stored encrypted in inode)
+              └─► Master Key (HKDF-Expand)
                     │
-                    └─► Per-Block Key (HKDF-Expand with block index)
+                    ├─► Commit Key (HKDF-Expand)
+                    │
+                    ├─► Metadata Key (HKDF-Expand)
+                    │     │
+                    │     └─► Per-Inode Key (HKDF-Expand with inode_id, see Section 7.1)
+                    │           │
+                    │           └─► Per-Block Key (HKDF-Expand with block index)
+                    │
+                    ├─► Per-Blob Auth Key (HKDF-Expand with share_id, see Section 11.2)
+                    │
+                    └─► Per-File Key (HKDF-Expand with file_id)
+                          │
+                          └─► Per-Block Key (HKDF-Expand with block index)
 ```
 
-The master storage key is derived from the storage nsec (not the raw user nsec):
+The master storage key is derived from the storage nsec (not the raw user nsec) using the full HKDF (Extract-then-Expand) as defined in RFC 5869:
 
 ```
-master_key = HKDF-SHA256(
-    IKM = storage_nsec,
-    salt = None,
+# Step 1: Extract
+PRK = HKDF-Extract(
+    salt = 0x0000...00 (32 zero bytes),
+    IKM = storage_nsec
+)
+
+# Step 2: Expand
+master_key = HKDF-Expand(
+    PRK = PRK,
     info = "garland-v1:master",
     length = 32
 )
 ```
 
-Per RFC 5869, salt should be independent of IKM; using empty salt is explicitly permitted and avoids any dependency concerns. The storage_nsec already has high entropy from PBKDF2, so the extraction phase primarily provides domain separation via the info string. This derivation is fully deterministic: the same nsec + passphrase always produces the same master key, enabling recovery without storing additional secrets. The storage nsec derivation is described in Section 6.4.
+Per RFC 5869 Section 2.2, when salt is not provided, it defaults to a string of HashLen (32 for SHA-256) zero bytes. The storage_nsec already has high entropy from PBKDF2, so the extraction phase primarily provides domain separation. This derivation is fully deterministic: the same nsec + passphrase always produces the same master key, enabling recovery without storing additional secrets. The storage nsec derivation is described in Section 6.4.
 
-Purpose-specific keys are derived from the master key using HKDF-Expand (no additional salt needed since master_key is already a PRK):
+Purpose-specific keys are derived from the master key using HKDF-Expand only. The master_key is a 32-byte pseudorandom output of HKDF-Expand, which satisfies HKDF-Expand's input requirement of "a pseudorandom key of at least HashLen octets" (RFC 5869 Section 2.3):
 
 ```
 commit_key = HKDF-Expand(
@@ -304,9 +348,22 @@ metadata_key = HKDF-Expand(
 
 The commit key encrypts commit event content. The metadata key encrypts inodes and directory blobs. Separating these keys limits the impact of potential key compromise and clarifies the encryption scope.
 
-Each file receives a randomly generated 256-bit key at creation time. This per-file key is stored within the file's inode, encrypted with the metadata key. Random per-file keys ensure that identical files produce different ciphertexts, preventing content-based correlation.
+Single-block metadata MAY be encrypted directly under `metadata_key` for simplicity. Multi-block metadata derives a per-inode key from `metadata_key` as shown in the diagram and in Section 7.1.
 
-**File modification**: When a file is modified, the client creates a new inode with a freshly generated random file_key. The file_key is never reused across file versions. This is essential because the encryption uses a fixed zero nonce; reusing a file_key for different content would cause keystream reuse, enabling trivial plaintext recovery.
+Each file receives a randomly generated 256-bit `file_id` at creation time. This identifier is stored in plaintext within the inode and used to derive the file's encryption key:
+
+```
+file_id = random_bytes(32)
+file_key = HKDF-Expand(
+    PRK = master_key,
+    info = "garland-v1:file:" || file_id,
+    length = 32
+)
+```
+
+This derivation provides cryptographic separation between metadata and content. An attacker who compromises `metadata_key` can decrypt inodes and learn file structure, but cannot derive `file_key` without `master_key`. The `file_id` in plaintext is meaningless without `master_key`.
+
+**File modification**: When a file is modified, the client creates a new inode with a freshly generated `file_id`. This ensures each file version uses a unique `file_key`, preventing key reuse across versions.
 
 Per-block keys are derived from the file key:
 
@@ -320,19 +377,53 @@ block_key = HKDF-Expand(
 
 ### 6.2 Encryption
 
-Each block is encrypted using ChaCha20, a stream cipher widely used in the Nostr ecosystem (NIP-44) and well-supported across platforms.
+Each block is encrypted using ChaCha20 (RFC 8439, IETF variant with 96-bit nonce, initial block counter = 0) with HMAC-SHA256 authentication, following a construction similar to NIP-44. This provides both confidentiality and authentication.
+
+To maintain cryptographic key separation, each block key is split into distinct encryption and authentication sub-keys via HKDF-Expand:
+
+```
+block_key = HKDF-Expand(K_f, "garland-v1:block:" || block_index_as_u64_be, 32)
+enc_key   = HKDF-Expand(block_key, "garland-v1:enc", 32)
+mac_key   = HKDF-Expand(block_key, "garland-v1:mac", 32)
+```
 
 The encryption process for block i with file key K_f:
 
 ```
 block_key = HKDF-Expand(K_f, "garland-v1:block:" || i, 32)
-nonce = 0x000000000000000000000000  (12 zero bytes)
-ciphertext = ChaCha20(block_key, nonce, plaintext_block)
+enc_key = HKDF-Expand(block_key, "garland-v1:enc", 32)
+mac_key = HKDF-Expand(block_key, "garland-v1:mac", 32)
+nonce = random_bytes(12)
+ciphertext = ChaCha20(enc_key, nonce, plaintext_block)
+mac = HMAC-SHA256(mac_key, nonce || ciphertext)
+encrypted_block = nonce || ciphertext || mac
 ```
 
-Since each block uses a unique derived key, a fixed zero nonce is cryptographically safe: the (key, nonce) pair is never reused. This avoids 12 bytes of overhead per block.
+The encrypted block format is:
 
-Integrity is provided by the content-addressing scheme. Each share is stored and retrieved by its SHA-256 hash, and if a server returns data that doesn't match the requested hash, it is rejected. After decryption, the plaintext block hash is verified against the value stored in the inode. This layered integrity checking at the storage layer makes encryption-layer authentication unnecessary.
+```
+[nonce: 12 bytes][ciphertext: B - 44 bytes][mac: 32 bytes]
+```
+
+**Key separation**: Deriving separate `enc_key` and `mac_key` from each `block_key` avoids dual-use keying.
+
+**Random nonces**: Each block uses a freshly generated random nonce, providing defense-in-depth against implementation bugs that might cause key reuse.
+
+**Authentication**: The HMAC authenticates both the nonce and ciphertext, detecting tampering before decryption. This complements the content-addressing integrity check by catching corruption earlier.
+
+**Decryption process**:
+
+```
+nonce = encrypted_block[0:12]
+ciphertext = encrypted_block[12:-32]
+mac = encrypted_block[-32:]
+enc_key = HKDF-Expand(block_key, "garland-v1:enc", 32)
+mac_key = HKDF-Expand(block_key, "garland-v1:mac", 32)
+expected_mac = HMAC-SHA256(mac_key, nonce || ciphertext)
+if not constant_time_compare(mac, expected_mac):
+    reject("authentication failed")
+plaintext = ChaCha20(enc_key, nonce, ciphertext)
+```
 
 ### 6.3 Metadata Encryption
 
@@ -356,6 +447,27 @@ The resulting shares are indistinguishable from file data shares. See Section 14
 
 ### 6.4 Storage Identity Derivation
 
+Whenever this protocol derives a secp256k1 private key from pseudorandom bytes, implementations MUST use the following rejection-sampling procedure:
+
+```
+SECP256K1_N = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+
+function derive_secp256k1_scalar(prk: bytes[32], info: bytes) -> bytes[32]:
+    counter = 0
+    while true:
+        candidate = HKDF-Expand(
+            PRK = prk,
+            info = info || u32_be(counter),
+            length = 32
+        )
+        x = bytes_to_uint256(candidate)
+        if 0 < x < SECP256K1_N:
+            return candidate
+        counter += 1
+```
+
+Implementations MUST NOT reduce candidates modulo the curve order.
+
 The storage nsec is always derived from the user's nsec combined with a passphrase. This derivation serves two purposes: it separates the storage identity from the user's social Nostr identity, and it enables multiple independent storage buckets via different passphrases.
 
 ```
@@ -367,10 +479,11 @@ function derive_storage_nsec(nsec: bytes[32], passphrase: string) -> bytes[32]:
         iterations = 210000,
         output_length = 32
     )
-    return HMAC-SHA256(key = "garland-v1-nsec", message = nsec || stretched)
+    seed = HMAC-SHA256(key = "garland-v1-nsec", message = nsec || stretched)
+    return derive_secp256k1_scalar(seed, "garland-v1:storage-scalar")
 ```
 
-The derivation uses only primitives present in the Nostr ecosystem (HMAC-SHA256, PBKDF2, secp256k1), avoiding new dependencies. PBKDF2 (Password-Based Key Derivation Function 2) deliberately slows key derivation through repeated hashing, making brute-force attacks expensive. The identity-bound salt prevents rainbow tables across users. The 210,000 iteration count follows OWASP 2023 guidelines for PBKDF2-HMAC-SHA256. The derived output is used directly as a secp256k1 private key.
+The derivation uses only primitives present in the Nostr ecosystem (HMAC-SHA256, PBKDF2, secp256k1), avoiding new dependencies. PBKDF2 (Password-Based Key Derivation Function 2) deliberately slows key derivation through repeated hashing, making brute-force attacks expensive. The identity-bound salt prevents rainbow tables across users. The 210,000 iteration count follows OWASP 2023 guidelines for PBKDF2-HMAC-SHA256. The final rejection-sampling step guarantees a valid secp256k1 private key with deterministic behavior across implementations.
 
 **Default passphrase**: When no passphrase is specified, the empty string is used. This is not a special case; the derivation runs identically with `passphrase = ""`. The empty-string bucket serves as the default storage location.
 
@@ -908,7 +1021,7 @@ The `{sha256}` path component is the lowercase hex-encoded SHA-256 hash of the b
 
 ### 11.2 Authentication
 
-Some servers require authentication for write operations (PUT, DELETE) via a Nostr event in the Authorization header. Other servers operate openly without authentication.
+Some servers require authentication for write operations (PUT, DELETE) via a Nostr event in the Authorization header. Other servers operate openly without authentication. Share descriptors record this as `auth: "none"`.
 
 #### Per-Blob Authentication Keys
 
@@ -943,7 +1056,7 @@ The authorization event has kind 24242:
     ["x", "<sha256 of blob being uploaded>"],
     ["expiration", "1701910800"]
   ],
-  "content": "",
+  "content": "garland upload authorization",
   "sig": "<signature from per-blob key>"
 }
 ```
@@ -956,11 +1069,15 @@ With per-blob keys, each blob appears to come from a different user. Servers can
 
 For servers requiring a billing relationship or account management, users may opt into identity key mode, where all authorizations use the storage identity pubkey directly. This enables per-user quotas and billing but allows the server to correlate all blobs to the same owner.
 
-Identity key mode is selected per-server in client configuration. Users should prefer per-blob keys for privacy-focused servers and identity keys only where billing integration requires it.
+Identity key mode is selected per-server in client configuration and recorded as `auth: "identity"` in stored share descriptors. Open servers are recorded as `auth: "none"`. Users should prefer per-blob keys for privacy-focused servers and identity keys only where billing integration requires it.
 
 #### Server Verification
 
-Servers verify the signature, confirm the kind is 24242, check that the action matches the `t` tag, validate that the current time is before expiration, and verify the `x` tag matches the blob hash. Servers do not need to know which authentication mode the client uses; they simply verify valid signatures.
+Servers verify the signature, confirm the kind is 24242, check that the action matches the `t` tag, validate that the current time is before expiration, and verify the `x` tag matches the blob hash.
+
+For authenticated servers, Garland defines an additional delete-ownership rule: the upload authorization also establishes delete authority. A Garland-compatible server MUST persist the authorization pubkey used for each accepted blob hash. A later `DELETE /{sha256}` MUST be accepted only if the authorization event is signed by the same pubkey that authorized the upload, or by an account-level key explicitly configured by the server for identity-key mode. A valid signature by some unrelated pubkey is not sufficient.
+
+This rule is stricter than baseline Blossom interoperability. A generic Blossom server that does not implement Garland's delete-ownership rule is still usable as an append-only server for `PUT`, `GET`, and `HEAD`, but Garland clients MUST NOT assume that `DELETE` will work safely there. Clients SHOULD mark such servers as non-GC targets.
 
 ### 11.3 Server Responses
 
@@ -976,7 +1093,13 @@ Successful upload returns a blob descriptor:
 }
 ```
 
-The URL may differ from the upload endpoint if the server uses a CDN or different domain for retrieval.
+The `url` may differ from the upload endpoint if the server uses a CDN or different domain for retrieval.
+
+Clients MUST persist both write and read semantics in share descriptors:
+- `server`: the authenticated write/delete origin used for `PUT /upload` and `DELETE /{sha256}`
+- `url`: the absolute retrieval URL returned by the server for `GET`/`HEAD`
+
+If the returned `url` is exactly `server + "/" + sha256`, clients MAY omit `url` from stored metadata and derive it on demand. If it differs, clients MUST store it explicitly.
 
 GET requests return the raw blob bytes with appropriate headers:
 
@@ -990,16 +1113,28 @@ HEAD requests return the same headers without the body, enabling existence check
 
 ### 11.4 Server Interchangeability
 
-Blossom servers are interchangeable and fungible. A blob uploaded to server A can be retrieved from server B if server B also has it. The content hash serves as a universal identifier across all servers.
+Blossom servers are interchangeable in that any server can store and serve any blob by its content hash. However, inodes explicitly bind specific server URLs for each share:
 
-This interchangeability enables several patterns:
+```json
+{
+  "shares": [
+    {"id": "<share0_hash>", "server": "https://blossom1.example.com", "url": "https://cdn1.example.com/<share0_hash>", "auth": "blob"},
+    {"id": "<share1_hash>", "server": "https://blossom2.example.com", "auth": "blob"},
+    {"id": "<share2_hash>", "server": "https://blossom3.example.com", "auth": "blob"}
+  ]
+}
+```
 
-- **Mirroring**: Upload the same blob to multiple servers for redundancy
-- **Migration**: Move from one server to another by re-uploading
-- **CDN integration**: Servers can replicate blobs to edge locations
-- **Opportunistic caching**: Clients can check multiple servers and use whichever responds fastest
+Clients fetch shares from `url` when present, otherwise from `server/{id}`. Uploads and deletes always target the `server` origin. There is no automatic discovery mechanism for finding alternative servers that may also host a given share.
 
-The system's erasure coding distributes shares across servers, so migration requires uploading only shares to replacement servers, not the full reconstructed blob.
+In practice, "interchangeability" means:
+
+- **Flexible fetching**: Clients can choose which k of n listed servers to fetch from
+- **Repair via replacement**: Failed servers can be replaced by uploading shares to new servers and updating the inode
+- **Migration**: Move from one server to another by re-uploading shares and updating references
+- **CDN integration**: Servers can replicate blobs to edge locations transparently
+
+The system does not include automatic discovery of alternative servers hosting a given share.
 
 ---
 
@@ -1540,14 +1675,109 @@ Significant work remains for production deployment. Payment integration, automat
 
 ---
 
-## Appendix: Recommended Parameters
+## Appendix A: Recommended Parameters
 
 | Parameter | Value | Rationale |
 |-----------|-------|-----------|
-| Block size | 256 KiB | Balance between padding overhead and chunking granularity |
+| Block size (B) | 262,144 bytes (256 KiB) | Fixed for all k values; balance between padding overhead and chunking granularity |
+| Plaintext frame (C) | B - 44 = 262,100 bytes | Reserves space for 12-byte nonce + 32-byte MAC |
+| Content capacity (C_eff) | C - 4 = 262,096 bytes | Reserves 4 bytes for length prefix in every block |
 | Erasure coding | (n=5, k=3) | Tolerates 2 failures with 67% overhead |
-| Encryption | ChaCha20 | Simple, fast, integrity via content addressing |
+| Encryption | ChaCha20 (RFC 8439) + HMAC-SHA256 | IETF variant, 96-bit nonce, NIP-44 aligned |
 | Key derivation | HKDF-SHA256 | Standard, widely implemented |
 | Commit relays | 5+ | Ensures retrievability despite relay failures |
 | Verification | Weekly | Balances failure detection and bandwidth |
 | Passphrase KDF | PBKDF2, 210k iterations | OWASP 2023 aligned, ~0.5-1s derivation |
+
+---
+
+## Appendix B: Reed-Solomon Test Vectors
+
+All implementations MUST verify compatibility against these test vectors before deployment. These vectors were generated with `github.com/klauspost/reedsolomon` v1.12.4 using default settings (systematic encoding over GF(2^8)).
+
+The common test input is the 12-byte block:
+
+```
+Input (hex): 000102030405060708090a0b
+```
+
+### (k=1, n=3)
+
+```
+Share 0: 000102030405060708090a0b
+Share 1: 000102030405060708090a0b
+Share 2: 000102030405060708090a0b
+```
+
+Reconstruction check: any 1 share reproduces the input block exactly.
+
+### (k=2, n=3)
+
+```
+Share 0: 000102030405
+Share 1: 060708090a0b
+Share 2: 0c0d16171819
+```
+
+Reconstruction check: shares {0,2} and shares {1,2} both reconstruct `000102030405060708090a0b`.
+
+### (k=3, n=5)
+
+```
+Share 0: 00010203
+Share 1: 04050607
+Share 2: 08090a0b
+Share 3: 0c0d0e0f
+Share 4: 10111213
+```
+
+Reconstruction check: shares {0,3,4} reconstruct `000102030405060708090a0b`.
+
+### (k=4, n=6)
+
+```
+Share 0: 000102
+Share 1: 030405
+Share 2: 060708
+Share 3: 090a0b
+Share 4: fc9d56
+Share 5: d7a849
+```
+
+Reconstruction check: shares {0,2,4,5} reconstruct `000102030405060708090a0b`.
+
+### (k=4, n=7)
+
+```
+Share 0: 000102
+Share 1: 030405
+Share 2: 060708
+Share 3: 090a0b
+Share 4: fc9d56
+Share 5: d7a849
+Share 6: 9adb7c
+```
+
+Reconstruction check: shares {1,3,4,6} reconstruct `000102030405060708090a0b`.
+
+### (k=6, n=9)
+
+```
+Share 0: 0001
+Share 1: 0203
+Share 2: 0405
+Share 3: 0607
+Share 4: 0809
+Share 5: 0a0b
+Share 6: 0c0d
+Share 7: 0e0f
+Share 8: 1011
+```
+
+Reconstruction check: shares {0,2,4,6,7,8} reconstruct `000102030405060708090a0b`.
+
+Implementations SHOULD also publish machine-readable test vectors covering:
+1. RS padding when `B mod k != 0`
+2. Block framing and canonical payload hashes
+3. Storage identity derivation and secp256k1 scalar rejection sampling
+4. Commit encryption and inode-reference serialization

--- a/garland-v0.1.md
+++ b/garland-v0.1.md
@@ -821,35 +821,56 @@ A commit event has the following structure:
   "kind": 1097,
   "pubkey": "<owner's public key>",
   "created_at": 1701907200,
-  "tags": [
-    ["prev", "<event ID of previous commit>"]
-  ],
+  "tags": [],
   "content": "<encrypted payload>",
   "sig": "<Schnorr signature>"
 }
 ```
 
-The `prev` tag contains the event ID of the immediately preceding commit, creating the chain. The genesis commit omits this tag. The `created_at` timestamp provides temporal ordering; Nostr relays serve events in reverse chronological order by default, enabling efficient head discovery (see Section 9.5).
+The commit event has no tags. All metadata is encrypted within the `content` field. The `created_at` timestamp is a relay-level ordering hint; Nostr relays serve events in reverse chronological order by default, which helps clients discover recent commit candidates but does not define the canonical head.
 
-The client encrypts the `content` field using ChaCha20 with the commit key derived from the master storage key (see Section 6.1). It contains:
+The client encrypts the `content` field using the enc/mac key split (Section 6.2) applied to the commit key:
+
+```
+enc_key = HKDF-Expand(commit_key, "garland-v1:enc", 32)
+mac_key = HKDF-Expand(commit_key, "garland-v1:mac", 32)
+nonce = random_bytes(12)
+ciphertext = ChaCha20(enc_key, nonce, plaintext)
+mac = HMAC-SHA256(mac_key, nonce || ciphertext)
+content = base64(nonce || ciphertext || mac)
+```
+
+The nonce is prepended to the ciphertext within the base64-encoded content, not stored in a tag.
+
+The decrypted content contains:
 
 ```json
 {
+  "prev": "<event ID of previous commit, or null for genesis>",
+  "seq": 42,
   "root_inode": {
+    "format": "single",
     "hash": "<content hash of root directory inode>",
+    "erasure": {"algorithm": "reed-solomon", "k": 2, "n": 3, "field": "gf256"},
     "shares": [
-      {"id": "<share_hash>", "server": "https://blossom1.example.com"},
-      {"id": "<share_hash>", "server": "https://blossom2.example.com"},
-      {"id": "<share_hash>", "server": "https://blossom3.example.com"}
+      {"id": "<share_hash>", "server": "https://blossom1.example.com", "auth": "blob"},
+      {"id": "<share_hash>", "server": "https://blossom2.example.com", "auth": "blob"},
+      {"id": "<share_hash>", "server": "https://blossom3.example.com", "auth": "blob"}
     ]
   },
-  "erasure": {"k": 2, "n": 3},
-  "garbage": ["<hash1>", "<hash2>"],
+  "garbage": [
+    {"id": "<share_id>", "server": "https://blossom1.example.com", "auth": "blob"},
+    {"id": "<share_id>", "server": "https://blossom2.example.com", "auth": "blob"}
+  ],
   "message": "Added vacation photos"
 }
 ```
 
-The `root_inode` field contains the content hash and share locations for the root directory blob. The `garbage` array lists blob hashes that are no longer referenced as of this commit and may be deleted from storage servers. The optional `message` field allows human-readable commit descriptions.
+The `prev` field contains the event ID of the immediately preceding commit, creating the chain. The genesis commit sets `prev` to null. Encrypting `prev` hides the commit chain structure from observers, who see only that commits exist but not how they link together.
+
+The `seq` field is a monotonically increasing non-negative integer, starting at 0 for the genesis commit. It MUST remain within the I-JSON safe integer range `0 <= seq <= 2^53 - 1`. For every non-genesis commit, implementations MUST enforce `child.seq = parent.seq + 1`. Clients MAY use `created_at` as a relay query hint, but they MUST NOT use it as the canonical fork-choice rule. A client that has previously accepted a head SHOULD persist its `(event_id, seq)` locally and treat any lower-seq candidate head as stale unless the user explicitly enters recovery mode. The `seq` value is inside the encrypted content, so it is not visible to relays or observers.
+
+The `root_inode` field contains the full inode reference for the root directory, including whatever share locations are needed to fetch it. The `garbage` array lists share IDs, server URLs, and auth modes for shares that are no longer referenced as of this commit and may become deletion candidates (see Section 13.3). The optional `message` field allows human-readable commit descriptions.
 
 ### 9.2 Commit Process
 
@@ -887,13 +908,13 @@ Between saves, the local state may be lost if the device fails. This is acceptab
 
 ### 9.4 Chain Traversal and History
 
-The complete history is recoverable by walking the chain backward from the head. Each commit's `prev` tag leads to its predecessor until reaching the genesis commit, which omits the `prev` tag entirely.
+The complete history is recoverable by walking the chain backward from the head. Each commit's `prev` field (within the encrypted content) leads to its predecessor until reaching the genesis commit (which has `prev: null`).
 
 ```
 HEAD ──prev──► Commit N-1 ──prev──► Commit N-2 ──prev──► ... ──prev──► Genesis
 ```
 
-Clients can implement time-travel functionality: given any historical commit, they can reconstruct the exact filesystem state at that point by using the commit's root hash to traverse the Merkle DAG.
+Clients can implement time-travel functionality: given any historical commit, they can reconstruct the exact filesystem state at that point by using the commit's `root_inode` reference to traverse the Merkle DAG.
 
 This history has storage implications. Old commits reference old blobs which must be retained for history to remain valid. Users who don't need history can garbage collect aggressively. Users who value history must retain more data. Section 13 discusses garbage collection in detail.
 
@@ -903,51 +924,62 @@ The commit chain requires two operations: finding the current head for normal us
 
 #### Finding the Chain Head
 
-Nostr relays return events in reverse chronological order by `created_at` timestamp. To find the current chain head, clients query for kind 1097 events with `limit=1`:
+Nostr relays return events in reverse chronological order by `created_at` timestamp. Clients MAY use a `limit=1` query as a latency optimization to discover recent candidates, but the result is only a hint:
 
 ```
 REQ: ["REQ", <sub_id>, {"kinds": [1097], "authors": [<pubkey>], "limit": 1}]
 ```
 
-The relay returns the most recent commit event. In normal operation, where commits are created sequentially from a single device or with proper conflict resolution, this is the chain head.
+The relay returns the most recent commit event by timestamp, not necessarily the canonical head. Clients MUST validate candidate heads by fetching commit events from all configured storage relays, decrypting them, and applying the sequence and ancestry rules below.
 
-If different relays return different "most recent" events (due to propagation delays or clock skew), clients should fall back to full chain traversal to determine the true head. Fetch all commits, build the chain graph, and identify the canonical head as described below.
+In steady-state operation, a client can usually stop after it has found one valid tip with the highest observed `seq` and confirmed that no configured relay exposes a competing tip at the same or higher `seq`. If that condition does not hold, the client MUST fall back to full chain traversal.
 
 #### Full Chain Traversal
 
 For disaster recovery or history reconstruction, clients traverse the complete chain:
 
-1. Query for all kind 1097 events by the owner's pubkey (no limit)
-2. Build an index: `event_id → event` and `prev → event_id`
-3. Identify the head: the event whose ID appears in no other event's `prev` tag
-4. Walk backward via `prev` tags until reaching genesis (the commit with no `prev` tag)
+1. Query all configured storage relays for kind 1097 events by the owner's pubkey (no limit, or enough pages to exhaust the relay's results)
+2. Decrypt each commit's content to extract its `prev` field
+3. Discard any commit whose parent is missing, whose `seq` does not equal `parent.seq + 1`, whose MAC fails, or whose plaintext does not match the schema in Section 9.1. The only exception is genesis: exactly one commit may use `prev = null`, and it MUST have `seq = 0`.
+4. Build indexes: `event_id → event`, `prev → child events`, and `seq → tip candidates`
+5. Identify valid tips: commits whose IDs appear in no other valid commit's `prev` field
+6. If exactly one valid tip has the highest observed `seq`, treat it as the head
+7. If multiple valid tips share the highest observed `seq`, the chain is forked; the client MUST stop automatic head selection and require reconciliation
+8. Walk backward via `prev` fields until reaching genesis (the commit with `prev: null`)
 
-This traversal reconstructs the complete history without requiring any decryption. The chain structure is visible in plaintext `prev` tags; only the content (root hashes, garbage lists, messages) requires decryption.
+Since `prev` is encrypted, chain traversal requires decrypting all commits. This is acceptable because:
+- Commits are small (a few hundred bytes each)
+- Decryption is fast (ChaCha20 + HMAC verification)
+- Commits must be decrypted anyway to access their content
+- The privacy benefit (hiding chain structure) outweighs the cost
 
 #### Fork Detection
 
-Forks occur when two commits share the same `prev` value, meaning both claim to follow the same parent. During traversal:
+Forks occur when two or more valid commits share the same `prev` value, meaning they all claim to follow the same parent.
 
-1. If multiple events have the same `prev`, a fork exists
-2. The event with the later `created_at` timestamp is the canonical head
-3. The other branch may contain commits that need merging or represent conflicting changes
+1. If multiple valid events have the same `prev`, a fork exists
+2. `created_at` MAY be shown in UI, but it MUST NOT be used to pick the canonical branch
+3. Garland v0.1 commits have exactly one parent (`prev`). They do not encode multi-parent merges.
+4. A conflict ends only when the user or application selects one branch as canonical and publishes a new descendant commit from that chosen tip. Any incorporation of changes from another branch is an application-level operation that produces ordinary single-parent commits.
+5. Until user-directed reconciliation occurs, the bucket is in conflict state and clients MUST NOT run garbage collection
 
 For personal single-device usage, forks are rare. Multi-device deployments should implement merge strategies (Section 9.2).
 
 ### 9.6 Metadata Privacy
 
-Commit events are publicly visible on relays. To minimize metadata leakage, sensitive fields are encrypted within the `content` field:
+Commit events are publicly visible on relays. To minimize metadata leakage, all fields except those required by Nostr are encrypted within the `content` field:
 
-- **Root hash**: Stored only in encrypted content. Observers cannot detect when the filesystem changes or correlate commits with blob uploads.
-- **Garbage list**: Stored only in encrypted content. Observers cannot determine when data is being deleted.
-- **Commit message**: Stored only in encrypted content.
+- **Prev pointer**: Encrypted. Observers cannot see how commits link together.
+- **Root inode reference**: Encrypted. Observers cannot detect when the filesystem changes or correlate commits with blob uploads.
+- **Garbage list**: Encrypted. Observers cannot determine when data is being deleted.
+- **Commit message**: Encrypted.
 
 The only plaintext metadata exposed is:
-- The `prev` tag linking to the parent commit (necessary for chain traversal)
 - The `created_at` timestamp (required by Nostr protocol)
 - The owner's public key (inherent to Nostr signatures)
+- The existence of commits (event count reveals activity frequency)
 
-The `prev` tag reveals chain structure but not contents. Observers can count commits and analyze timing patterns from `created_at` timestamps, but cannot determine what changed between commits or how much data each commit affects. Users concerned about timing analysis can batch commits or add random delays to `created_at` values (within Nostr's tolerance for clock skew).
+Observers can count commits and analyze timing patterns from `created_at` timestamps, but cannot determine what changed between commits, how much data each commit affects, or how commits relate to each other. Users concerned about timing analysis can batch commits or add random delays to `created_at` values (within Nostr's tolerance for clock skew).
 
 ---
 
@@ -955,19 +987,19 @@ The `prev` tag reveals chain structure but not contents. Observers can count com
 
 ### 10.1 Recovery Process
 
-Disaster recovery requires the owner's Nostr secret key (nsec) and passphrase (empty string if none was set). No backup files, no secondary credentials, no trusted third party. The recovery process:
+Disaster recovery requires the owner's Nostr secret key (nsec) and passphrase (empty string if none was set). No secondary decryption key or trusted third party is required. Operational recovery still assumes access to at least one relay that retained the commit chain, or a previously cached/exported relay list. The recovery process:
 
 1. **Derive storage identity**: Combine nsec + passphrase to derive storage nsec (Section 6.4)
 2. **Derive storage npub**: Compute public key from storage nsec using secp256k1
 3. **Discover relays**: Use client-configured storage relays (see Section 10.2)
 4. **Derive master key**: Compute master storage key from storage nsec via HKDF
-5. **Find chain head**: Query relays for kind 1097 events with author = storage npub and limit = 1; the most recent commit by `created_at` is the head
+5. **Find chain head**: Query all configured relays for kind 1097 events with author = storage npub, decrypt the returned commits, and select the unique valid tip with the highest `seq` as described in Section 9.5
 6. **Decrypt commit**: Decrypt the head commit's content field using the commit key derived from master key
-7. **Fetch root**: Download k shares of the root directory inode using URLs from the commit
+7. **Fetch root**: Download k shares of the root directory inode using the `root_inode` reference from the commit
 8. **Decode and decrypt**: Erasure-decode and decrypt the root directory
 9. **Traverse**: Recursively fetch any desired files through the directory structure
 
-For full history recovery, omit the limit parameter in step 4, fetch all commits, and traverse the chain via `prev` tags as described in Section 9.5.
+For full history recovery, omit the limit parameter in step 4, fetch all commits, and traverse the chain via encrypted `prev` fields as described in Section 9.5.
 
 The Nostr relay network serves as the discovery layer. Relays are interchangeable: the client can query any relay that might have stored the owner's events. Since events are signed, their authenticity is verifiable regardless of which relay provides them.
 
@@ -975,9 +1007,34 @@ The Nostr relay network serves as the discovery layer. Relays are interchangeabl
 
 Recovery reliability depends on commit events being retrievable from at least one relay. Users should publish commits to multiple relays and periodically verify that relays still hold their events.
 
-**Storage relay list**: Clients maintain an encrypted list of relays dedicated to storage commits. This list is stored within the storage system itself (as an encrypted blob) and also cached locally. The relay list is independent of the user's social NIP-65 relay list, preventing linkage between storage and social identities.
+**Storage relay list**: Clients maintain an encrypted list of relays dedicated to storage commits. This list is stored within the storage system itself as a small metadata inode referenced from the root directory under a reserved internal path such as `/.garland/relays.json`, and it is also cached locally. The relay list is independent of the user's social NIP-65 relay list, preventing linkage between storage and social identities.
 
-For initial setup or recovery without a cached relay list, clients use a hardcoded set of well-known public relays to bootstrap. Once the commit chain is located, the encrypted relay list can be retrieved and decrypted for ongoing use.
+The relay-list plaintext is a JCS-serialized JSON object:
+
+```json
+{
+  "version": 1,
+  "relays": [
+    "wss://relay1.example.com",
+    "wss://relay2.example.com"
+  ],
+  "updated": 1701907200
+}
+```
+
+Clients SHOULD also support an optional exported recovery checkpoint containing:
+- the storage pubkey
+- the relay list
+- the highest accepted `(seq, event_id)` pair
+
+Backup-oriented implementations SHOULD enable encrypted export/import of this checkpoint by default.
+
+For initial setup or recovery without a cached relay list, clients use a hardcoded set of well-known public relays to bootstrap. Once the commit chain is located, the encrypted relay list can be retrieved and decrypted for ongoing use. Because relay retention is an operational assumption rather than a cryptographic guarantee, clients SHOULD offer an export/import mechanism for the relay list and highest accepted head as a recovery aid.
+
+If a client has a local or imported recovery checkpoint, recovery MUST apply these anti-rollback rules:
+- If the discovered tip has lower `seq` than the checkpoint, the client MUST stop and require manual recovery.
+- If the discovered tip has the same `seq` but a different `event_id`, the client MUST treat the bucket as forked.
+- Clients MUST NOT run garbage collection from an unanchored recovery session that lacks either a trusted checkpoint or a previously accepted local head.
 
 Relay selection strategies include:
 
@@ -1151,7 +1208,7 @@ A steward is a process (potentially running on a dedicated server, a home machin
 3. Detects failures and initiates repair when shares become unavailable
 4. Updates the commit chain with new share locations after repair
 
-The steward requires sufficient credentials to perform these operations. In the simplest model, it holds the owner's nsec (or derived storage nsec if using passphrase protection). More sophisticated deployments might use delegated keys with limited authority, sufficient to read manifests and upload replacement shares but unable to delete data or modify directory structure.
+The steward requires sufficient credentials to perform these operations. In Garland v0.1, a fully capable steward requires the owner's nsec (or derived storage nsec if using passphrase protection), because it must read manifests, upload replacement shares, and publish repair commits. Delegated or reduced-authority steward keys are future work, not part of the v0.1 interoperability surface.
 
 The verification frequency depends on the user's durability requirements and tolerance for data loss. Weekly verification catches most server failures before they cascade. Daily verification provides stronger guarantees at higher bandwidth cost. Users with critical data might verify continuously, while archival users might verify monthly.
 
@@ -1206,32 +1263,17 @@ This guarantees the server holds the exact data, at the cost of downloading ever
 
 #### Privacy-Preserving Verification via Server Filters
 
-Blossom servers may publish probabilistic data structures (such as fuse filters) listing all blob hashes they store. Clients can query these filters locally without revealing which specific blobs they're checking. Fuse filters are a modern alternative to Bloom filters, offering better space efficiency and query performance while providing the same probabilistic membership testing.
+Probabilistic server filters (for example fuse filters listing stored blob hashes) are a promising future extension, but Garland v0.1 does not standardize their endpoint, format, or capability negotiation. Implementations MAY experiment with them out of band, but they are not part of the interoperable verification surface for v0.1.
 
-```
-GET /filter
-→ Returns fuse filter of all stored blob hashes
-
-Client checks: share_hash ∈ filter?
-```
-
-| Aspect | Assessment |
-|--------|------------|
-| Bandwidth | Low: download filter once, check many blobs locally |
-| Privacy | Good: server cannot determine which blobs client is verifying |
-| Integrity | None: confirms server claims to have the blob; does not verify content |
-| Implementation | Requires server support; filter format must be standardized |
-
-This approach can be combined with selective content verification: use filters for routine existence checks, then perform byte-range verification on a random sample or when filters indicate potential issues.
+For interoperable v0.1 deployments, verification MUST assume only the `HEAD`, `GET`, and optional `Range` behaviors described above.
 
 #### Hybrid Verification Strategy
 
 A practical deployment might combine approaches:
 
-1. **Daily**: Download server filters, check all shares exist in filters
-2. **Weekly**: Perform HEAD requests for any shares not covered by filters
-3. **Monthly**: Download and fully verify a random 1% sample of shares
-4. **On suspicion**: Fully verify any share that failed a lighter check
+1. **Daily or weekly**: Perform HEAD requests for all tracked shares
+2. **Monthly**: Download and fully verify a random 1% sample of shares
+3. **On suspicion**: Use byte-range or full-share verification for any share that failed a lighter check
 
 This balances bandwidth, privacy, and integrity while catching most failure modes.
 
@@ -1257,15 +1299,31 @@ When verification detects that share i of block b is unavailable or corrupted:
 
 9. **Commit**: Publish a new commit event with the updated root, referencing the previous commit.
 
-**Local file optimization**: If the client has the original file locally, steps 2-3 can be skipped entirely. Re-encrypt the local block with the same file key and block index (producing identical ciphertext), then re-encode to generate the missing share. This avoids downloading k shares over the network and is significantly faster.
+**Local file optimization**: If the client has the original file locally, steps 2-3 can be replaced with a full-block rewrite path. Re-encrypt the local block with the same file key and block index (with a fresh random nonce, producing different ciphertext), then re-encode to generate a completely new set of n shares. Because re-encryption changes the ciphertext and thus every share hash, the client MUST treat this as replacing the entire block version: all share IDs for that block change, all corresponding share descriptors must be rewritten, and any newly obsolete shares become garbage candidates. This optimization avoids downloading k shares over the network, but it is not equivalent to regenerating only the missing share from the recovered encrypted block.
 
 Repair from remote shares is expensive: it requires downloading k full shares (potentially hundreds of kilobytes each) and uploading at least one new share. However, repair occurs only on failure, and early detection prevents cascading failures that could make blocks unrecoverable.
 
-### 12.4 Steward Authority
+### 12.4 Verification and Authentication Mode Interaction
+
+Per-blob authentication keys (Section 11.2) prevent servers from correlating blobs to a single owner. However, this also prevents the server from enumerating "all blobs belonging to user X," which limits server-side verification capabilities. Identity-key servers can verify exhaustively but see all blobs.
+
+Users may designate servers into two tiers:
+
+**Identity-key servers**: Use the storage identity pubkey for authentication. These servers can enumerate all blobs for the user, enabling billing, quotas, and owner-level verification. The user sacrifices per-blob unlinkability on these servers.
+
+**Per-blob-key servers**: Use per-blob derived keys. These servers provide strong privacy (each blob appears to belong to a different user) but cannot perform owner-level verification.
+
+The protocol does not require any fixed number of identity-key servers. If a deployment uses them, clients SHOULD minimize their number and clearly warn that those servers can correlate uploads, repairs, and deletions for the associated storage identity.
+
+For per-blob-key servers, the client can perform random sampling verification: periodically download and verify 5-10% of shares stored on these servers. This catches corruption or data loss probabilistically without requiring the server to know which user the blobs belong to.
+
+### 12.5 Steward Authority
 
 Currently, a steward requires the full storage nsec to perform repairs. Both Blossom uploads (kind 24242 authorization) and commit events (kind 1097) require signatures from the storage keypair. There is no mechanism for delegated or restricted authority with current Nostr primitives.
 
 This means steward compromise is equivalent to full account compromise. Users must weigh the availability benefits of automated repair against the risk of key exposure. See Section 17.2 for discussion of potential protocol extensions enabling fine-grained delegation.
+
+Servers MUST default to `gc_capable = false` unless they are explicitly configured by the client as Garland-compatible delete targets. Clients MUST NOT attempt protocol-driven garbage collection against servers that are not known GC-capable. Servers using `auth: "none"` MUST be treated as append-only and non-GC unless the client has explicit, out-of-band knowledge that safe deletion is supported.
 
 ---
 
@@ -1277,54 +1335,102 @@ Content-addressed immutable storage naturally accumulates data. Updating a file 
 
 This design places garbage collection responsibility entirely with the client. The system does not automatically delete anything. Users must explicitly choose to delete obsolete data, accepting the tradeoff between storage costs and history preservation.
 
+Clients MUST persist the highest accepted `(seq, event_id)` locally after each successful sync. Clients SHOULD include this pair in the optional exported recovery checkpoint described in Section 10.2. Garbage collection MUST NOT run from a session that lacks either a previously accepted local head or a trusted imported checkpoint.
+
 ### 13.2 Reference Tracking
 
 The client maintains knowledge of which blobs are reachable from each commit. A blob is garbage if it's unreachable from any commit the user wishes to preserve.
 
-Computing reachability requires traversing the Merkle DAG from each preserved commit's root. The traversal must handle each blob type appropriately:
+Computing reachability requires traversing the Merkle DAG from each preserved commit's root. The traversal handles all blob types uniformly:
 
-**Directory blobs**: Extract `entries[i].hash` for each entry; these are content hashes of child inodes. Also collect the directory blob's own share IDs (from the parent's reference to it).
+**Inode references**: Each reference (in directory entries or commit content) is either `format: "single"` (has `hash`, `erasure`, and `shares`) or `format: "multi"` (has `inode_id`, `erasure`, and `blocks`). Collect all share IDs from the reference, then fetch and decrypt to traverse the inode's contents.
 
-**File inodes**: Extract `blocks[i].shares[j].id` for all shares of all blocks; these are the share hashes stored on servers. Also collect the inode blob's own share IDs. Note that the `blocks[i].hash` field is a plaintext integrity hash, not a server-stored blob.
+**File inodes**: Extract `blocks[i].shares[j].id` for all file content shares.
 
-**Large file inodes**: Extract `block_index_chunks[i].shares[j].id` for all indirect block shares, then traverse each indirect block to collect the actual content share IDs within.
-
-**Indirect block chunks**: Extract `blocks[i].shares[j].id` for all content shares referenced by this chunk.
+**Directory inodes**: For each entry, collect its inode reference shares, then recursively traverse the child inode.
 
 ```
 reachable_shares = {}
 
+def collect_inode_ref_shares(ref):
+    """Collect shares from a single-block or multi-block inode reference."""
+    if ref.format == "multi":
+        for block in ref.blocks:
+            for share in block.shares:
+                reachable_shares.add(share.id)
+    else:
+        for share in ref.shares:
+            reachable_shares.add(share.id)
+
 def traverse_from_commit(commit):
-    root_inode_shares = commit.root_inode.shares
-    for share in root_inode_shares:
-        reachable_shares.add(share.id)
-    traverse_inode(fetch_and_decrypt(root_inode_shares))
+    collect_inode_ref_shares(commit.root_inode)
+    root = fetch_and_decrypt(commit.root_inode)
+    traverse_inode(root)
 
 def traverse_inode(inode):
     if inode.type == "directory":
-        for entry in inode.entries:
-            for share in entry.shares:
-                reachable_shares.add(share.id)
-            child = fetch_and_decrypt(entry.shares)
+        for entry in inode.entries.values():
+            collect_inode_ref_shares(entry.ref)
+            child = fetch_and_decrypt(entry.ref)
             traverse_inode(child)
     elif inode.type == "file":
-        if inode.blocks:  # direct blocks
+        if inode.inline:
+            pass  # inline content lives inside the inode blob; no separate shares
+        else:
             for block in inode.blocks:
                 for share in block.shares:
                     reachable_shares.add(share.id)
-        if inode.block_index_chunks:  # large file indirect blocks
-            for chunk in inode.block_index_chunks:
-                for share in chunk.shares:
-                    reachable_shares.add(share.id)
-                indirect = fetch_and_decrypt(chunk.shares)
-                for block in indirect.blocks:
-                    for share in block.shares:
-                        reachable_shares.add(share.id)
 ```
 
 Shares not in `reachable_shares` are candidates for deletion. This includes old file content, old inodes, and old directory blobs from previous versions.
 
-### 13.3 Deletion Strategies
+### 13.3 Incremental Garbage Collection
+
+The `garbage` array in each commit (Section 9.1) lists shares that became newly unreachable relative to that commit's immediate parent. Each entry contains the share_id (SHA-256 of the share bytes), the server URL, and the auth mode needed to delete that share:
+
+```json
+"garbage": [
+    {"id": "<share_id>", "server": "https://blossom1.example.com", "auth": "blob"},
+    {"id": "<share_id>", "server": "https://blossom2.example.com", "auth": "identity"}
+]
+```
+
+Using share-level entries (rather than block-level hashes) avoids a chicken-and-egg problem: if garbage contained only block hashes, the client would need old inodes to resolve which share_ids to delete from which servers, but those old inodes may themselves be garbage. With share_ids and server URLs directly in the garbage array, each entry is a precise deletion candidate.
+
+The `garbage` array is an optimization hint, not the source of truth for safe deletion. Before deleting any share, clients MUST verify that the share is unreachable from every commit or snapshot the user intends to preserve. Clients MUST NOT run garbage collection while unresolved forks exist.
+
+This enables incremental collection with a safety check:
+
+```
+def incremental_gc(discarded_commits, preserved_commits, grace_period_seconds):
+    reachable = compute_reachable_shares(preserved_commits)
+    for commit in discarded_commits:
+        if now() - commit.created_at < grace_period_seconds:
+            continue
+        for entry in commit.garbage:
+            if entry.id not in reachable:
+                delete_share(entry.server, entry.id, entry.auth)
+```
+
+**Algorithm:**
+
+1. Decide which commits you will preserve
+2. Compute the reachable share set from that preserved set (Section 13.2)
+3. Build the list of discarded commits whose `garbage` arrays provide deletion candidates
+4. Wait a configurable grace period before deleting candidates; the default SHOULD be 30 days
+5. Delete only those candidate shares that are still absent from the preserved reachable set
+6. Optionally delete obsolete commit events from relays after blob GC completes
+
+This approach:
+- Uses the preserved reachable set as the safety-critical source of truth
+- Uses the `garbage` array to avoid re-deriving every deletion candidate from old state
+- Works incrementally as new commits are created
+- Provides a grace window for stale clients or delayed reconciliation
+- Keeps each garbage entry self-contained (share_id + server URL + auth mode)
+
+**Example**: To keep only the last 30 days of history, identify the commits to preserve, compute their reachable shares, then process garbage entries from older commits after the grace period. Delete only the entries absent from the preserved reachable set.
+
+### 13.4 Retention Strategies
 
 Several strategies for garbage collection exist, offering different tradeoffs:
 
@@ -1336,20 +1442,23 @@ Several strategies for garbage collection exist, offering different tradeoffs:
 
 **Explicit snapshots**: Mark specific commits as preserved (e.g., monthly snapshots, pre-migration backups). Delete blobs unreachable from any preserved commit.
 
-### 13.4 Deletion Process
+### 13.5 Deletion Process
 
-To delete a garbage blob, all n shares must be deleted from their respective servers. Partial deletion leaves the blob reconstructable from surviving shares.
+To fully delete obsolete data, all shares of the garbage blobs must be deleted from their respective servers. Partial deletion leaves the blob reconstructable from surviving shares.
 
-To delete garbage blobs:
+To delete garbage shares:
 
-1. Compute the set of blob hashes to delete
-2. For each blob, look up all n share locations from the inode
-3. For each share on each server:
-   - Generate a deletion authorization event
-   - Send DELETE request with authorization
-4. Publish a commit with the `garbage` field listing the deleted blob hashes
+1. Collect all share entries from the `garbage` arrays of the commits being cleaned up (each entry contains a share_id, server URL, and auth mode)
+2. For each share entry:
+   - Confirm that the share is unreachable from every preserved commit or snapshot
+   - Confirm that no unresolved fork exists and that the grace period has elapsed
+   - Select the deletion mode based on `entry.auth`: derive the per-blob auth key for `"blob"`, use the storage identity key for `"identity"`, or send no Authorization header for `"none"`
+   - Generate a deletion authorization event when `entry.auth` is `"blob"` or `"identity"`
+   - Send `DELETE /{share_id}` to the listed server using that mode
 
-The commit's `garbage` field serves as an announcement of intent. It signals to future clients examining history that these blobs were deliberately deleted and should not be considered missing or corrupted. Note that these hashes, while encrypted within the commit, could theoretically be correlated by an adversary who previously observed blob uploads, though this requires both passive observation of uploads and access to decrypted commits.
+If a server recorded as `auth: "none"` does not support unauthenticated deletion, clients MUST treat it as a non-GC target and plan retention accordingly.
+
+The commit's `garbage` field records when a share first became unreachable. It does not prove that deletion already happened. Clients examining history should treat a share listed in `garbage` as a deletion candidate, not an already-deleted object. The share_ids, while encrypted within the commit, could theoretically be correlated by an adversary who previously observed share uploads, though this requires both passive observation of uploads and access to decrypted commits.
 
 Deletion authorization uses the same Nostr event mechanism as uploads:
 
@@ -1361,22 +1470,16 @@ Deletion authorization uses the same Nostr event mechanism as uploads:
     ["x", "<sha256 of blob to delete>"],
     ["expiration", "1701910800"]
   ],
-  "content": "Garbage collection",
+  "content": "garland delete authorization",
   "sig": "<signature>"
 }
 ```
 
-### 13.5 Metadata Event Garbage Collection
+### 13.6 Metadata Event Retention
 
-The hash chain of commit events also accumulates over time. Old commit events may be pruned from relays to reduce storage, but this requires care.
+Garland v0.1 requires commit-chain continuity for interoperable recovery and head validation. Because every non-genesis commit validates against its parent, clients and relays MUST retain the full commit chain. Interior pruning is not part of the v0.1 interoperability surface.
 
-Safe deletion criteria for commit events:
-
-- The commit's blobs have been garbage collected (no point keeping metadata for deleted data)
-- The commit is not the chain head or a preserved snapshot
-- Sufficient time has passed that no client might be traversing through it
-
-In practice, commit events are small (kilobytes) and relay storage is cheap. Most users can retain their complete commit history indefinitely. Users with extremely long histories or storage-constrained relays can prune old commits, accepting that history before the pruning point becomes inaccessible.
+In practice, commit events are small (kilobytes) and relay storage is cheap. Most users can retain their complete commit history indefinitely. Future protocol versions may define checkpointing or re-anchoring mechanisms that permit safe pruning, but v0.1 does not.
 
 ---
 
@@ -1389,7 +1492,7 @@ This section provides the consolidated privacy analysis for security review. It 
 From any individual Blossom server's perspective:
 
 **Observable:**
-- Fixed-size encrypted blobs, all identical in size
+- Fixed-size encrypted shares, all identical in size for a given (B, k) configuration (share size = (B + pad) / k bytes, where pad accounts for RS alignment; see Section 5.2)
 - The SHA-256 hash of each blob (used as identifier)
 - A unique public key per blob (from per-blob authentication, see Section 11.2)
 - Timestamps of upload, access, and deletion requests
@@ -1416,19 +1519,20 @@ Relays storing commit events observe:
 **Observable:**
 - The public key publishing commits (owner identity or derived storage identity)
 - The `created_at` timestamp of each commit
-- The `prev` tag linking commits into a chain
 - The encrypted `content` field (opaque ciphertext)
 - The total number of commits over time
 - Timing patterns of commit activity
 
 **Not observable:**
-- The root hash or any blob references (encrypted in content)
+- The `prev` pointer linking commits (encrypted in content)
+- The root inode reference or any blob references (encrypted in content)
 - Commit messages (encrypted in content)
 - Garbage collection lists (encrypted in content)
 - What changed between commits
 - Dataset size or structure
+- How commits relate to each other (chain structure hidden)
 
-The `prev` tag reveals that commits form a chain but not what the chain contains. An observer can count commits and analyze timing but cannot determine whether a commit added one file or a thousand, or whether it deleted data via garbage collection.
+Observers can count commits and analyze timing but cannot determine whether a commit added one file or a thousand, whether it deleted data via garbage collection, or how commits link together.
 
 ### 14.3 Cross-Server Correlation
 
@@ -1457,6 +1561,7 @@ Even with correlation, the adversary learns only about activity patterns, not co
 | Storage identity | Relays only | Per-blob keys prevent server correlation |
 | Number of commits | Relays | Batch changes into fewer commits |
 | IP address | Servers and relays | Tor, VPN, proxy rotation |
+| Erasure coding parameter k | Cross-server observers (share size = B/k) | Negligible attack value; k is system-wide, not per-file; per-blob auth prevents linking to a user on a single server |
 
 With per-blob authentication keys, individual Blossom servers cannot determine per-user storage volume. Only colluding servers that combine timing analysis can attempt to correlate blobs, and even then, the link is probabilistic rather than cryptographic.
 
@@ -1485,13 +1590,13 @@ To add a file to the storage system:
 
 1. Read the file content
 2. Divide into fixed-size blocks with padding
-3. Generate a random per-file encryption key
+3. Generate a random file_id and derive the file encryption key
 4. For each block:
-   - Derive the block encryption key
-   - Encrypt with ChaCha20
+   - Derive block_key, then split into enc_key and mac_key (Section 6.2)
+   - Encrypt with ChaCha20 + HMAC-SHA256 using the split keys
    - Erasure-code into n shares
    - Upload shares to n servers
-5. Construct the inode with block metadata
+5. Construct the inode with file_id and block metadata
 6. Encrypt and upload the inode blob
 7. Update the parent directory to include the new entry
 8. Recursively update ancestors to the root
@@ -1501,8 +1606,8 @@ To add a file to the storage system:
 
 When the user saves:
 
-1. Fetch current chain head from relays
-2. Verify local changes are based on this head
+1. Fetch commit candidates from all configured relays
+2. Select the unique highest-seq valid head, or stop for reconciliation if the chain is forked
 3. Upload all staged blobs (files, inodes, directories)
 4. Construct commit event with new root and prev reference
 5. Sign and publish commit to relays
@@ -1512,8 +1617,8 @@ When the user saves:
 
 To read a file by path:
 
-1. Fetch current chain head
-2. Decrypt commit to obtain root blob location
+1. Fetch commit candidates from configured relays and select the unique valid head
+2. Decrypt commit to obtain the `root_inode` reference
 3. Traverse directory structure to target inode
 4. For each block in the inode:
    - Attempt to fetch k shares from listed servers
@@ -1528,8 +1633,8 @@ Periodically, the client should verify data availability:
 
 1. For each blob referenced by the current state:
    - For each share of that blob:
-     - Check existence via HEAD request, server fuse filters, or byte range request
-     - Optionally, download and verify full hash matches
+      - Check existence via HEAD request or byte range request
+      - Optionally, download and verify full hash matches
 2. If any blob has fewer than k available shares:
    - Fetch k surviving shares
    - Erasure-decode to recover the block
@@ -1547,7 +1652,7 @@ When storage costs warrant cleanup:
 3. Identify unreachable blobs
 4. Delete unreachable blobs from servers
 5. Optionally delete obsolete commit events from relays
-6. Record garbage collection in next commit
+6. Optionally record the maintenance action in a local GC log
 
 ---
 
@@ -1564,11 +1669,11 @@ Storage servers observe only uniformly-sized encrypted blobs. They cannot determ
 - Directory structure (directories are encrypted like files)
 - Relationships between blobs (no plaintext linking)
 
-The encryption is semantically secure: identical plaintexts produce different ciphertexts due to random per-file keys. Servers cannot detect when users store the same content.
+The encryption is semantically secure: identical plaintexts produce different ciphertexts due to random per-file keys and random nonces. Servers cannot detect when users store the same content.
 
 ### 16.2 Integrity
 
-Content addressing provides integrity at multiple levels. Share hashes verify individual share integrity. Block hashes (stored in inodes) verify decrypted block integrity. The Merkle DAG structure verifies structural integrity: any modification to any blob changes the root hash.
+Content addressing provides integrity at multiple levels. Share hashes verify individual share integrity. Block hashes (stored in inodes) verify decrypted block integrity. The Merkle DAG structure verifies structural integrity: any modification to any blob changes the root inode reference carried by later commits.
 
 Content addressing detects ciphertext tampering. If an attacker modifies stored data, the SHA-256 hash will not match the share ID, and the data will be rejected before decryption is attempted.
 


### PR DESCRIPTION
## Summary
- make commit recovery and head selection seq-based, encrypted, and checkpoint-aware
- narrow v0.1 verification to interoperable server behavior while clarifying repair and authentication tradeoffs
- tighten garbage-collection safety, relay retention, and lifecycle text so clients do not delete from ambiguous state